### PR TITLE
chore(ci): add dependabot for website npm deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
     interval: weekly
   ignore:
     - dependency-name: "*"
+- package-ecosystem: npm
+  directory: "/website"
+  schedule:
+    interval: weekly
+  reviewers:
+    - sassman
 - package-ecosystem: "github-actions"
   directory: "/"
   # Check for updates every Monday


### PR DESCRIPTION
## Summary
- Adds an `npm` package ecosystem entry to `.github/dependabot.yml` for the `/website` directory
- Ensures VitePress and other website dependencies get automated weekly update PRs

## Test plan
- [ ] Verify dependabot picks up the new ecosystem config after merge