### PR TITLE
fix(am): shell wrappers don't reload after 'profile use'

### DIFF
--- a/crates/am/src/shell_wrappers/wrapper.fish
+++ b/crates/am/src/shell_wrappers/wrapper.fish
@@ -13,7 +13,7 @@ function am --wraps=am
     end
     # profile mutation → reload aliases
     if begin; test "$argv[1]" = profile; or test "$argv[1]" = p; end
-        if begin; test "$argv[2]" = set; or test "$argv[2]" = s; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
+        if begin; test "$argv[2]" = use; or test "$argv[2]" = u; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
             command am reload __SHELL__ | source
         end
     else if begin; test "$argv[1]" = add; or test "$argv[1]" = a; or test "$argv[1]" = remove; or test "$argv[1]" = r; end

--- a/crates/am/src/shell_wrappers/wrapper.ps1
+++ b/crates/am/src/shell_wrappers/wrapper.ps1
@@ -13,7 +13,7 @@ function am {
     }
     # profile mutation — reload
     if ($args.Count -ge 1 -and $args[0] -in 'profile', 'p') {
-        if ($args.Count -ge 2 -and $args[1] -in 'set', 's', 'use', 'u', 'add', 'a', 'remove', 'r') {
+        if ($args.Count -ge 2 -and $args[1] -in 'use', 'u', 'add', 'a', 'remove', 'r') {
             $out = (& $amBin reload __SHELL__) -join "`r`n"
             if ($out) { Invoke-Command -ScriptBlock ([scriptblock]::Create($out)) -NoNewScope }
         }

--- a/crates/am/src/shell_wrappers/wrapper.zsh
+++ b/crates/am/src/shell_wrappers/wrapper.zsh
@@ -6,7 +6,7 @@ am() {
     tui|t) eval "$(command am reload __SHELL__)"; eval "$(command am hook __SHELL__)"; return ;;
   esac
   case "$1:$2" in
-    profile:set|p:set|profile:s|p:s|profile:add|p:add|profile:a|p:a|profile:remove|p:remove|profile:r|p:r) eval "$(command am reload __SHELL__)" ;;
+    profile:use|p:use|profile:u|p:u|profile:add|p:add|profile:a|p:a|profile:remove|p:remove|profile:r|p:r) eval "$(command am reload __SHELL__)" ;;
   esac
   case "$1" in
     add|a|remove|r)

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_deep_chain.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_deep_chain.snap
@@ -23,7 +23,7 @@ function am --wraps=am
     end
     # profile mutation → reload aliases
     if begin; test "$argv[1]" = profile; or test "$argv[1]" = p; end
-        if begin; test "$argv[2]" = set; or test "$argv[2]" = s; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
+        if begin; test "$argv[2]" = use; or test "$argv[2]" = u; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
             command am reload fish | source
         end
     else if begin; test "$argv[1]" = add; or test "$argv[1]" = a; or test "$argv[1]" = remove; or test "$argv[1]" = r; end

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_globals_and_multi_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_globals_and_multi_profile.snap
@@ -26,7 +26,7 @@ function am --wraps=am
     end
     # profile mutation → reload aliases
     if begin; test "$argv[1]" = profile; or test "$argv[1]" = p; end
-        if begin; test "$argv[2]" = set; or test "$argv[2]" = s; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
+        if begin; test "$argv[2]" = use; or test "$argv[2]" = u; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
             command am reload fish | source
         end
     else if begin; test "$argv[1]" = add; or test "$argv[1]" = a; or test "$argv[1]" = remove; or test "$argv[1]" = r; end

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_multi_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_multi_profile.snap
@@ -25,7 +25,7 @@ function am --wraps=am
     end
     # profile mutation → reload aliases
     if begin; test "$argv[1]" = profile; or test "$argv[1]" = p; end
-        if begin; test "$argv[2]" = set; or test "$argv[2]" = s; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
+        if begin; test "$argv[2]" = use; or test "$argv[2]" = u; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
             command am reload fish | source
         end
     else if begin; test "$argv[1]" = add; or test "$argv[1]" = a; or test "$argv[1]" = remove; or test "$argv[1]" = r; end

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_simple_profile.snap
@@ -22,7 +22,7 @@ function am --wraps=am
     end
     # profile mutation → reload aliases
     if begin; test "$argv[1]" = profile; or test "$argv[1]" = p; end
-        if begin; test "$argv[2]" = set; or test "$argv[2]" = s; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
+        if begin; test "$argv[2]" = use; or test "$argv[2]" = u; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
             command am reload fish | source
         end
     else if begin; test "$argv[1]" = add; or test "$argv[1]" = a; or test "$argv[1]" = remove; or test "$argv[1]" = r; end

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_globals.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_globals.snap
@@ -22,7 +22,7 @@ function am --wraps=am
     end
     # profile mutation → reload aliases
     if begin; test "$argv[1]" = profile; or test "$argv[1]" = p; end
-        if begin; test "$argv[2]" = set; or test "$argv[2]" = s; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
+        if begin; test "$argv[2]" = use; or test "$argv[2]" = u; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
             command am reload fish | source
         end
     else if begin; test "$argv[1]" = add; or test "$argv[1]" = a; or test "$argv[1]" = remove; or test "$argv[1]" = r; end

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
@@ -22,7 +22,7 @@ function am {
     }
     # profile mutation — reload
     if ($args.Count -ge 1 -and $args[0] -in 'profile', 'p') {
-        if ($args.Count -ge 2 -and $args[1] -in 'set', 's', 'use', 'u', 'add', 'a', 'remove', 'r') {
+        if ($args.Count -ge 2 -and $args[1] -in 'use', 'u', 'add', 'a', 'remove', 'r') {
             $out = (& $amBin reload powershell) -join "`r`n"
             if ($out) { Invoke-Command -ScriptBlock ([scriptblock]::Create($out)) -NoNewScope }
         }

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_zsh_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_zsh_simple_profile.snap
@@ -15,7 +15,7 @@ am() {
     tui|t) eval "$(command am reload zsh)"; eval "$(command am hook zsh)"; return ;;
   esac
   case "$1:$2" in
-    profile:set|p:set|profile:s|p:s|profile:add|p:add|profile:a|p:a|profile:remove|p:remove|profile:r|p:r) eval "$(command am reload zsh)" ;;
+    profile:use|p:use|profile:u|p:u|profile:add|p:add|profile:a|p:a|profile:remove|p:remove|profile:r|p:r) eval "$(command am reload zsh)" ;;
   esac
   case "$1" in
     add|a|remove|r)


### PR DESCRIPTION
## Summary

- Shell wrappers (fish, zsh) matched stale subcommand name `set`/`s` instead of `use`/`u`, so `am profile use <name>` never triggered `am reload` — profile aliases were saved to config but not loaded into the running shell
- Also removed the stale `set`/`s` from the PowerShell wrapper which had both old and new names

## Test plan

- [x] All 195 tests pass (115 unit + 24 snapshot + 56 TUI)
- [x] Snapshot tests updated to reflect the corrected wrapper code
- [x] Manual verification: `am profile use show-case` now loads aliases into the shell