### PR TITLE
community: add sassman-rust-essentials

### DIFF
--- a/community/sassman-rust-essentials/README.md
+++ b/community/sassman-rust-essentials/README.md
@@ -1,0 +1,32 @@
+---
+author: sassman
+description: Rust development shortcuts for fmt, lint, and test
+category: rust
+tags: [rust, cargo, testing, linting]
+profiles: [rust]
+---
+
+# Rust Essentials
+
+Three aliases I use on every Rust project — format, lint, test. Nothing fancy, just less typing.
+
+## Aliases
+
+| Alias | Expands to | When I use it |
+|-------|-----------|---------------|
+| `f` | `cargo fmt` | Format before committing |
+| `l` | `cargo clippy --locked --all-targets -- -D warnings` | Lint with strict warnings |
+| `t` | `cargo test --all-features` | Run the full test suite |
+
+## Typical workflow
+
+```bash
+f           # format
+l           # lint — fix anything clippy complains about
+t           # test — make sure nothing broke
+```
+
+## Notes
+
+- `l` uses `--locked` to ensure the lockfile is respected and `-D warnings` to treat warnings as errors
+- `t` uses `--all-features` to test everything, not just the default feature set

--- a/community/sassman-rust-essentials/profiles.toml
+++ b/community/sassman-rust-essentials/profiles.toml
@@ -1,0 +1,7 @@
+[[profiles]]
+name = "rust"
+
+[profiles.aliases]
+f = "cargo fmt"
+l = "cargo clippy --locked --all-targets -- -D warnings"
+t = "cargo test --all-features"


### PR DESCRIPTION
## Community Profile Submission

**Folder:** `community/sassman-rust-essentials/`

### Checklist

- [x] Copied template: `cp -r community/TEMPLATE community/sassman-rust-essentials`
- [x] Replaced `profiles.toml` with output of `am export -p rust`
- [x] Edited `README.md` frontmatter (`author`, `description`, `category`, `tags`, `profiles`)
- [x] README explains what the aliases do and how to use them
- [x] Only added/modified files in my own `community/sassman-rust-essentials/` folder
- [x] Tested import works: `am import community/sassman-rust-essentials/profiles.toml --yes`

### What does this profile collection do?

Three essential Rust development shortcuts: `f` (format), `l` (lint with strict clippy), `t` (test all features). The daily driver aliases for any Rust project.