### PR TITLE
feat: brush shell integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,14 @@ The crate is called `amoxide`, but the binary it installs is simply `am` (short 
 | Fish | Fully supported and tested |
 | PowerShell | Supported and tested (5.1 + 7) |
 | Zsh | Supported, not yet tested |
-| Bash, Nushell | Not yet implemented |
+| Bash | Supported (3.2+) |
+| Brush | Supported (bash-compatible) |
+| Nushell | Not yet implemented |
 
 ## Quick Setup
 
 ```sh
-am setup fish          # or: zsh, powershell
+am setup fish          # or: zsh, bash, brush, powershell
 ```
 
 Then add your first alias:

--- a/crates/am/src/cli.rs
+++ b/crates/am/src/cli.rs
@@ -56,13 +56,14 @@ pub enum Commands {
     /// a cd hook for automatic project alias loading. Add one of these lines
     /// to your shell's config file:
     ///
-    ///   Fish        ~/.config/fish/config.fish    am init fish | source
-    ///   Zsh         ~/.zshrc                      eval "$(am init zsh)"
     ///   Bash        ~/.bashrc                     eval "$(am init bash)"
+    ///   Brush       ~/.brushrc                    eval "$(am init brush)"
+    ///   Fish        ~/.config/fish/config.fish    am init fish | source
     ///   Nushell     ~/.config/nushell/config.nu   am init nu | source
     ///   PowerShell  $PROFILE                      (am init powershell) -join "`n" | Invoke-Expression
+    ///   Zsh         ~/.zshrc                      eval "$(am init zsh)"
     ///
-    /// Note: Only fish, zsh, and powershell are currently supported. Others are planned.
+    /// Note: Nushell is not yet supported.
     #[command(verbatim_doc_comment)]
     Init { shell: Shells },
 

--- a/crates/am/src/init.rs
+++ b/crates/am/src/init.rs
@@ -121,7 +121,7 @@ fn shell_script(template: &str, shell: &Shells) -> String {
 
 fn am_wrapper(shell: &Shells) -> String {
     match shell {
-        Shells::Bash => shell_script(WRAPPER_BASH, shell),
+        Shells::Bash | Shells::Brush => shell_script(WRAPPER_BASH, shell),
         Shells::Fish => shell_script(WRAPPER_FISH, shell),
         Shells::Powershell => shell_script(WRAPPER_PS1, shell),
         Shells::Zsh => shell_script(WRAPPER_ZSH, shell),
@@ -130,7 +130,7 @@ fn am_wrapper(shell: &Shells) -> String {
 
 fn cd_hook_setup(shell: &Shells) -> String {
     match shell {
-        Shells::Bash => shell_script(HOOK_BASH, shell),
+        Shells::Bash | Shells::Brush => shell_script(HOOK_BASH, shell),
         Shells::Fish => shell_script(HOOK_FISH, shell),
         Shells::Powershell => shell_script(HOOK_PS1, shell),
         Shells::Zsh => shell_script(HOOK_ZSH, shell),
@@ -139,7 +139,9 @@ fn cd_hook_setup(shell: &Shells) -> String {
 
 fn completions(shell: &Shells) -> String {
     match shell {
-        Shells::Bash => include_str!(concat!(env!("OUT_DIR"), "/am.bash")).to_string(),
+        Shells::Bash | Shells::Brush => {
+            include_str!(concat!(env!("OUT_DIR"), "/am.bash")).to_string()
+        }
         Shells::Fish => COMPLETIONS_FISH.to_string(),
         Shells::Powershell => powershell_completions(),
         Shells::Zsh => COMPLETIONS_ZSH.to_string(),

--- a/crates/am/src/setup.rs
+++ b/crates/am/src/setup.rs
@@ -31,6 +31,10 @@ fn shell_config(shell: &Shells) -> (PathBuf, &'static str) {
             let home = crate::dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
             (home.join(".bashrc"), r#"eval "$(am init bash)""#)
         }
+        Shells::Brush => {
+            let home = crate::dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+            (home.join(".brushrc"), r#"eval "$(am init brush)""#)
+        }
         Shells::Fish => {
             let mut path = dirs_lite::config_dir().unwrap_or_else(|| PathBuf::from(".config"));
             path.push("fish/config.fish");
@@ -57,7 +61,7 @@ fn shell_config(shell: &Shells) -> (PathBuf, &'static str) {
 fn reload_hint(shell: &Shells, profile_path: &std::path::Path) -> String {
     let path = profile_path.display();
     match shell {
-        Shells::Bash => format!("Run: source {path}"),
+        Shells::Bash | Shells::Brush => format!("Run: source {path}"),
         Shells::Fish => format!("Run: source {path}"),
         Shells::Zsh => format!("Run: source {path}"),
         Shells::Powershell => format!(

--- a/crates/am/src/shell/brush.rs
+++ b/crates/am/src/shell/brush.rs
@@ -1,0 +1,23 @@
+use super::{NixShell, Shell};
+use crate::alias::AliasEntry;
+
+#[derive(Debug, Default)]
+pub struct Brush;
+
+impl Shell for Brush {
+    fn unalias(&self, alias_name: &str) -> String {
+        NixShell.unalias(alias_name)
+    }
+
+    fn alias(&self, entry: &AliasEntry) -> String {
+        NixShell.alias(entry)
+    }
+
+    fn set_env(&self, var_name: &str, value: &str) -> String {
+        NixShell.set_env(var_name, value)
+    }
+
+    fn unset_env(&self, var_name: &str) -> String {
+        NixShell.unset_env(var_name)
+    }
+}

--- a/crates/am/src/shell/mod.rs
+++ b/crates/am/src/shell/mod.rs
@@ -1,4 +1,5 @@
 mod bash;
+mod brush;
 mod fish;
 mod nix;
 mod powershell;
@@ -7,6 +8,7 @@ mod shell;
 mod zsh;
 
 pub use bash::*;
+pub use brush::*;
 pub use fish::*;
 pub use nix::*;
 pub use powershell::*;

--- a/crates/am/src/shell/shell.rs
+++ b/crates/am/src/shell/shell.rs
@@ -14,6 +14,7 @@ pub trait Shell: Send + Sync + Debug {
 #[derive(ValueEnum, Clone, Debug, PartialEq)]
 pub enum Shells {
     Bash,
+    Brush,
     // Elvish,
     Fish,
     // Ksh,
@@ -36,6 +37,7 @@ impl Display for Shells {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Shells::Bash => write!(f, "bash"),
+            Shells::Brush => write!(f, "brush"),
             // Shells::Elvish => write!(f, "elvish"),
             Shells::Fish => write!(f, "fish"),
             // Shells::Ksh => write!(f, "ksh"),
@@ -59,6 +61,7 @@ impl From<Shells> for Box<dyn Shell> {
         match shell {
             Shells::Zsh => Box::from(super::zsh::Zsh),
             Shells::Bash => Box::from(super::bash::Bash),
+            Shells::Brush => Box::from(super::brush::Brush),
             Shells::Fish => Box::from(super::fish::Fish),
             Shells::Powershell => Box::from(super::powershell::PowerShell),
             // #[cfg(windows)]

--- a/crates/am/src/status.rs
+++ b/crates/am/src/status.rs
@@ -87,6 +87,10 @@ pub fn check_shell_config() -> Check {
             home_dir().map(|h| h.join(".bashrc")),
             "eval \"$(am init bash)\"",
         ),
+        "brush" => (
+            home_dir().map(|h| h.join(".brushrc")),
+            "eval \"$(am init brush)\"",
+        ),
         "powershell" => {
             let path = crate::setup::detect_powershell_profile();
             (

--- a/website/de/faq.md
+++ b/website/de/faq.md
@@ -7,7 +7,9 @@
 | Fish | Vollständig unterstützt und getestet |
 | PowerShell | Unterstützt und getestet (5.1 + 7) |
 | Zsh | Unterstützt, noch nicht getestet |
-| Bash, Nushell | Noch nicht implementiert |
+| Bash | Unterstützt (3.2+) |
+| Brush | Unterstützt (bash-kompatibel) |
+| Nushell | Noch nicht implementiert |
 
 ## Wie unterscheidet sich das von Shell-Aliasen in meinen Dotfiles?
 

--- a/website/de/guide/index.md
+++ b/website/de/guide/index.md
@@ -35,7 +35,7 @@ cargo install amoxide amoxide-tui
 **2. Shell einrichten:**
 
 ```sh
-am setup fish          # oder: zsh, powershell
+am setup fish          # oder: zsh, bash, brush, powershell
 ```
 
 Das erkennt deine Profil-Datei, zeigt genau was hinzugefügt wird und fragt nach Bestätigung. Siehe [Shell-Einrichtung](/de/guide/setup) für den manuellen Weg.

--- a/website/de/guide/installation.md
+++ b/website/de/guide/installation.md
@@ -41,7 +41,9 @@ Der TUI-Companion (`am-tui`) ist ein separates Paket. Optional, aber empfohlen f
 | Fish | Vollständig unterstützt und getestet |
 | PowerShell | Unterstützt und getestet (5.1 + 7) |
 | Zsh | Unterstützt, noch nicht getestet |
-| Bash, Nushell | Noch nicht implementiert |
+| Bash | Unterstützt (3.2+) |
+| Brush | Unterstützt (bash-kompatibel) |
+| Nushell | Noch nicht implementiert |
 
 ## Befehle
 

--- a/website/de/guide/setup.md
+++ b/website/de/guide/setup.md
@@ -18,6 +18,14 @@ am setup zsh
 am setup powershell
 ```
 
+```sh [Bash (v0.4.0+)]
+am setup bash
+```
+
+```sh [Brush]
+am setup brush
+```
+
 :::
 
 Das erkennt deine Profil-Datei, zeigt genau was hinzugefügt wird und fragt nach Bestätigung.
@@ -41,6 +49,16 @@ eval "$(am init zsh)"
 ```powershell [PowerShell]
 # Zu deinem PowerShell-Profil hinzufügen (echo $PROFILE zeigt den Pfad)
 (am init powershell) -join "`n" | Invoke-Expression
+```
+
+```bash [Bash (v0.4.0+)]
+# ~/.bashrc
+eval "$(am init bash)"
+```
+
+```bash [Brush]
+# ~/.brushrc
+eval "$(am init brush)"
 ```
 
 :::

--- a/website/faq.md
+++ b/website/faq.md
@@ -8,6 +8,7 @@
 | PowerShell | Supported and tested (5.1 + 7) |
 | Zsh | Supported, not yet tested |
 | Bash | Supported (3.2+) |
+| Brush | Supported (bash-compatible) |
 | Nushell | Not yet implemented |
 
 ## How is this different from shell aliases in my dotfiles?

--- a/website/guide/index.md
+++ b/website/guide/index.md
@@ -35,7 +35,7 @@ cargo install amoxide amoxide-tui
 **2. Set up your shell:**
 
 ```sh
-am setup fish          # or: zsh, powershell
+am setup fish          # or: zsh, bash, brush, powershell
 ```
 
 This detects your profile file, shows exactly what it will add, and asks for confirmation. See [Shell Setup](/guide/setup) for the manual approach.

--- a/website/guide/installation.md
+++ b/website/guide/installation.md
@@ -42,6 +42,7 @@ The TUI companion (`am-tui`) is a separate install. It's optional but recommende
 | PowerShell | Supported and tested (5.1 + 7) |
 | Zsh | Supported, not yet tested |
 | Bash | Supported (3.2+) |
+| Brush | Supported (bash-compatible) |
 | Nushell | Not yet implemented |
 
 ## Subcommands

--- a/website/guide/setup.md
+++ b/website/guide/setup.md
@@ -22,6 +22,10 @@ am setup powershell
 am setup bash
 ```
 
+```sh [Brush]
+am setup brush
+```
+
 :::
 
 This detects your profile file, shows exactly what it will add, and asks for confirmation.
@@ -52,10 +56,15 @@ eval "$(am init zsh)"
 eval "$(am init bash)"
 ```
 
+```bash [Brush]
+# ~/.brushrc
+eval "$(am init brush)"
+```
+
 :::
 
-::: tip Bash load order
-If you use starship, oh-my-bash, or bash-it, add the `am init bash` line **after** their initialization. This ensures amoxide's cd hook isn't overwritten.
+::: tip Bash / Brush load order
+If you use starship, oh-my-bash, or bash-it, add the `am init` line **after** their initialization. This ensures amoxide's cd hook isn't overwritten.
 :::
 
 ## What the Init Does


### PR DESCRIPTION
## Summary

- Add [brush shell](https://github.com/reubeno/brush) support — brush is bash-compatible, so it reuses all nix shell primitives (aliases, env vars, wrappers, hooks, completions)
- `am init brush` / `am setup brush` target `~/.brushrc`
- Update shell support tables and setup docs (EN + DE)

Closes #70

## Test plan

- [x] All 289 existing tests pass
- [ ] Manual: `am init brush` outputs valid bash-compatible init script
- [ ] Manual: `am setup brush` targets `~/.brushrc` with correct init line