### PR TITLE
feat: separate session state into session.toml

### DIFF
--- a/crates/am-tui/src/tree.rs
+++ b/crates/am-tui/src/tree.rs
@@ -24,7 +24,7 @@ pub fn build_tree(app_model: &AppModel) -> Vec<TreeNode> {
     build_tree_from_parts(
         &app_model.config.aliases,
         app_model.profile_config(),
-        &app_model.config.active_profiles,
+        &app_model.session.active_profiles,
         app_model.project_aliases(),
         project_trust_state,
     )
@@ -35,7 +35,7 @@ pub fn build_dest_tree(app_model: &AppModel) -> Vec<TreeNode> {
     build_dest_tree_from_parts(
         &app_model.config.aliases,
         app_model.profile_config(),
-        &app_model.config.active_profiles,
+        &app_model.session.active_profiles,
         project_is_trusted,
     )
 }

--- a/crates/am-tui/src/update/mod.rs
+++ b/crates/am-tui/src/update/mod.rs
@@ -65,14 +65,14 @@ mod tests {
         let tree = build_tree_from_parts(
             &app_model.config.aliases,
             app_model.profile_config(),
-            &app_model.config.active_profiles,
+            &app_model.session.active_profiles,
             None,
             None,
         );
         let dest_tree = build_dest_tree_from_parts(
             &app_model.config.aliases,
             app_model.profile_config(),
-            &app_model.config.active_profiles,
+            &app_model.session.active_profiles,
             false,
         );
         TuiModel {
@@ -489,7 +489,7 @@ mod tests {
             .unwrap();
         model.cursor = rust_idx;
         update(&mut model, TuiMessage::UseProfile);
-        assert!(model.app_model.config.is_active("rust"));
+        assert!(model.app_model.session.is_active("rust"));
         let rust_idx = model
             .tree
             .iter()
@@ -497,7 +497,7 @@ mod tests {
             .unwrap();
         model.cursor = rust_idx;
         update(&mut model, TuiMessage::UseProfile);
-        assert!(!model.app_model.config.is_active("rust"));
+        assert!(!model.app_model.session.is_active("rust"));
     }
 
     #[test]
@@ -518,7 +518,7 @@ mod tests {
             .unwrap();
         model.cursor = git_idx;
         update(&mut model, TuiMessage::UseProfile);
-        assert!(model.app_model.config.is_active("git"));
+        assert!(model.app_model.session.is_active("git"));
 
         let rust_idx = model
             .tree
@@ -528,7 +528,7 @@ mod tests {
         model.cursor = rust_idx;
         update(&mut model, TuiMessage::UseProfileWithPriority(1));
         assert_eq!(
-            model.app_model.config.active_profiles,
+            model.app_model.session.active_profiles,
             vec!["rust".to_string(), "git".to_string()]
         );
     }

--- a/crates/am-tui/src/view.rs
+++ b/crates/am-tui/src/view.rs
@@ -176,7 +176,7 @@ fn render_right_column(frame: &mut Frame, model: &TuiModel, area: Rect) {
         };
 
         let (icon, label) =
-            header_content(node, model.app_model.config.activation_order(&node.label));
+            header_content(node, model.app_model.session.activation_order(&node.label));
         let (label_color, icon_color) = header_colors(node, is_cursor);
 
         lines.push(Line::from(vec![
@@ -360,7 +360,7 @@ fn render_tree_lines(model: &TuiModel) -> Vec<Line<'static>> {
                     TREE_CONNECTOR
                 };
                 let (icon, label) =
-                    header_content(node, model.app_model.config.activation_order(&node.label));
+                    header_content(node, model.app_model.session.activation_order(&node.label));
                 let (label_color, icon_color) = header_colors(node, is_cursor);
 
                 lines.push(Line::from(vec![

--- a/crates/am/src/config.rs
+++ b/crates/am/src/config.rs
@@ -9,8 +9,6 @@ const CONFIG_FILE: &str = "config.toml";
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Config {
     #[serde(default)]
-    pub active_profiles: Vec<String>,
-    #[serde(default)]
     pub aliases: AliasSet,
 }
 
@@ -70,31 +68,6 @@ impl Config {
             .ok_or_else(|| anyhow::anyhow!("Global alias '{name}' not found"))?;
         Ok(())
     }
-
-    pub fn toggle_profile(&mut self, name: String) {
-        if let Some(pos) = self.active_profiles.iter().position(|p| p == &name) {
-            self.active_profiles.remove(pos);
-        } else {
-            self.active_profiles.push(name);
-        }
-    }
-
-    pub fn activation_order(&self, name: &str) -> Option<usize> {
-        self.active_profiles
-            .iter()
-            .position(|p| p == name)
-            .map(|i| i + 1)
-    }
-
-    pub fn is_active(&self, name: &str) -> bool {
-        self.active_profiles.contains(&name.to_string())
-    }
-
-    pub fn use_profile_at(&mut self, name: String, priority: usize) {
-        self.active_profiles.retain(|p| p != &name);
-        let idx = (priority.saturating_sub(1)).min(self.active_profiles.len());
-        self.active_profiles.insert(idx, name);
-    }
 }
 
 #[cfg(test)]
@@ -105,7 +78,6 @@ mod tests {
     fn test_default_config_when_no_file() {
         let dir = tempfile::tempdir().unwrap();
         let config = Config::load_from(dir.path()).unwrap();
-        assert!(config.active_profiles.is_empty());
         assert!(config.aliases.is_empty());
     }
 
@@ -113,14 +85,12 @@ mod tests {
     fn test_save_and_load_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let mut config = Config {
-            active_profiles: vec!["rust".to_string()],
             aliases: AliasSet::default(),
         };
         config.add_alias("ll".to_string(), "ls -lha".to_string(), false);
         config.save_to(dir.path()).unwrap();
 
         let loaded = Config::load_from(dir.path()).unwrap();
-        assert_eq!(loaded.active_profiles, vec!["rust".to_string()]);
         assert_eq!(loaded.aliases.iter().count(), 1);
     }
 
@@ -142,82 +112,6 @@ mod tests {
     }
 
     #[test]
-    fn test_active_profiles_roundtrip() {
-        let dir = tempfile::tempdir().unwrap();
-        let config = Config {
-            active_profiles: vec!["git".to_string(), "rust".to_string()],
-            aliases: AliasSet::default(),
-        };
-        config.save_to(dir.path()).unwrap();
-
-        let loaded = Config::load_from(dir.path()).unwrap();
-        assert_eq!(
-            loaded.active_profiles,
-            vec!["git".to_string(), "rust".to_string()]
-        );
-    }
-
-    #[test]
-    fn test_toggle_profile_appends() {
-        let mut config = Config::default();
-        config.toggle_profile("git".to_string());
-        assert_eq!(config.active_profiles, vec!["git".to_string()]);
-        config.toggle_profile("rust".to_string());
-        assert_eq!(
-            config.active_profiles,
-            vec!["git".to_string(), "rust".to_string()]
-        );
-    }
-
-    #[test]
-    fn test_toggle_profile_removes() {
-        let mut config = Config {
-            active_profiles: vec!["git".to_string(), "rust".to_string()],
-            aliases: AliasSet::default(),
-        };
-        config.toggle_profile("git".to_string());
-        assert_eq!(config.active_profiles, vec!["rust".to_string()]);
-    }
-
-    #[test]
-    fn test_profile_activation_order() {
-        let config = Config {
-            active_profiles: vec!["git".to_string(), "rust".to_string(), "node".to_string()],
-            aliases: AliasSet::default(),
-        };
-        assert_eq!(config.activation_order("git"), Some(1));
-        assert_eq!(config.activation_order("rust"), Some(2));
-        assert_eq!(config.activation_order("node"), Some(3));
-        assert_eq!(config.activation_order("python"), None);
-    }
-
-    #[test]
-    fn test_use_profile_at_inserts_at_position() {
-        let mut config = Config {
-            active_profiles: vec!["git".to_string(), "rust".to_string()],
-            aliases: AliasSet::default(),
-        };
-        config.use_profile_at("node".to_string(), 1);
-        assert_eq!(
-            config.active_profiles,
-            vec!["node".to_string(), "git".to_string(), "rust".to_string(),]
-        );
-    }
-
-    #[test]
-    fn test_use_profile_at_repositions_existing() {
-        let mut config = Config {
-            active_profiles: vec!["git".to_string(), "rust".to_string(), "node".to_string()],
-            aliases: AliasSet::default(),
-        };
-        config.use_profile_at("node".to_string(), 1);
-        assert_eq!(
-            config.active_profiles,
-            vec!["node".to_string(), "git".to_string(), "rust".to_string(),]
-        );
-    }
-
-    #[test]
     fn test_merge_aliases_into_global() {
         let mut config = Config::default();
         config.add_alias("ll".into(), "ls -lha".into(), false);
@@ -233,19 +127,6 @@ mod tests {
                 .unwrap()
                 .command(),
             "ls -la"
-        );
-    }
-
-    #[test]
-    fn test_use_profile_at_clamps_to_end() {
-        let mut config = Config {
-            active_profiles: vec!["git".to_string()],
-            aliases: AliasSet::default(),
-        };
-        config.use_profile_at("rust".to_string(), 100);
-        assert_eq!(
-            config.active_profiles,
-            vec!["git".to_string(), "rust".to_string()]
         );
     }
 }

--- a/crates/am/src/effects.rs
+++ b/crates/am/src/effects.rs
@@ -1,6 +1,7 @@
 #[derive(Debug, Clone, PartialEq)]
 pub enum Effect {
     SaveConfig,
+    SaveSession,
     SaveProfiles,
     AddLocalAlias {
         name: String,
@@ -21,6 +22,7 @@ use crate::update::AppModel;
 pub fn execute_effect(model: &mut AppModel, effect: &Effect) -> anyhow::Result<()> {
     match effect {
         Effect::SaveConfig => model.save_config()?,
+        Effect::SaveSession => model.save_session()?,
         Effect::SaveProfiles => model.save_profiles()?,
         Effect::SaveSecurity => model.save_security()?,
         Effect::AddLocalAlias { name, cmd, raw } => {

--- a/crates/am/src/import_export.rs
+++ b/crates/am/src/import_export.rs
@@ -42,7 +42,7 @@ fn export_toml(model: &AppModel, args: &ExportArgs) -> anyhow::Result<String> {
     if !has_scope {
         // No flags: active scope (global + active profiles + local if present and trusted)
         let active_profiles: Vec<_> = model
-            .config
+            .session
             .active_profiles
             .iter()
             .filter_map(|name| model.profile_config().get_profile_by_name(name))

--- a/crates/am/src/lib.rs
+++ b/crates/am/src/lib.rs
@@ -17,6 +17,7 @@ pub mod security;
 pub mod setup;
 pub mod shell;
 pub mod status;
+pub mod session;
 pub mod trust;
 pub mod update;
 
@@ -28,6 +29,7 @@ pub use exchange::*;
 pub use messages::*;
 pub use profile::*;
 pub use project::*;
+pub use session::*;
 pub use update::UpdateError;
 
 pub type Result<T> = anyhow::Result<T>;

--- a/crates/am/src/lib.rs
+++ b/crates/am/src/lib.rs
@@ -14,10 +14,10 @@ pub mod profile;
 pub mod project;
 pub mod prompt;
 pub mod security;
+pub mod session;
 pub mod setup;
 pub mod shell;
 pub mod status;
-pub mod session;
 pub mod trust;
 pub mod update;
 

--- a/crates/am/src/session.rs
+++ b/crates/am/src/session.rs
@@ -1,0 +1,169 @@
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+const SESSION_FILE: &str = "session.toml";
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct Session {
+    #[serde(default)]
+    pub active_profiles: Vec<String>,
+}
+
+impl Session {
+    pub fn load_from(config_dir: &Path) -> crate::Result<Self> {
+        let path = config_dir.join(SESSION_FILE);
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let data = std::fs::read_to_string(path)?;
+        let session = toml::from_str(&data)?;
+        Ok(session)
+    }
+
+    pub fn save_to(&self, config_dir: &Path) -> crate::Result<()> {
+        if !config_dir.exists() {
+            std::fs::create_dir_all(config_dir)?;
+        }
+        let path = config_dir.join(SESSION_FILE);
+        let data = toml::to_string(self)?;
+        std::fs::write(path, data)?;
+        Ok(())
+    }
+
+    pub fn load() -> crate::Result<Self> {
+        Self::load_from(&crate::dirs::config_dir())
+    }
+
+    pub fn save(&self) -> crate::Result<()> {
+        self.save_to(&crate::dirs::config_dir())
+    }
+
+    pub fn toggle_profile(&mut self, name: String) {
+        if let Some(pos) = self.active_profiles.iter().position(|p| p == &name) {
+            self.active_profiles.remove(pos);
+        } else {
+            self.active_profiles.push(name);
+        }
+    }
+
+    pub fn activation_order(&self, name: &str) -> Option<usize> {
+        self.active_profiles
+            .iter()
+            .position(|p| p == name)
+            .map(|i| i + 1)
+    }
+
+    pub fn is_active(&self, name: &str) -> bool {
+        self.active_profiles.contains(&name.to_string())
+    }
+
+    pub fn use_profile_at(&mut self, name: String, priority: usize) {
+        self.active_profiles.retain(|p| p != &name);
+        let idx = (priority.saturating_sub(1)).min(self.active_profiles.len());
+        self.active_profiles.insert(idx, name);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_session_when_no_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let session = Session::load_from(dir.path()).unwrap();
+        assert!(session.active_profiles.is_empty());
+    }
+
+    #[test]
+    fn test_save_and_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let session = Session {
+            active_profiles: vec!["git".to_string(), "rust".to_string()],
+        };
+        session.save_to(dir.path()).unwrap();
+        let loaded = Session::load_from(dir.path()).unwrap();
+        assert_eq!(
+            loaded.active_profiles,
+            vec!["git".to_string(), "rust".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_toggle_profile_appends() {
+        let mut session = Session::default();
+        session.toggle_profile("git".to_string());
+        assert_eq!(session.active_profiles, vec!["git".to_string()]);
+        session.toggle_profile("rust".to_string());
+        assert_eq!(
+            session.active_profiles,
+            vec!["git".to_string(), "rust".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_toggle_profile_removes() {
+        let mut session = Session {
+            active_profiles: vec!["git".to_string(), "rust".to_string()],
+        };
+        session.toggle_profile("git".to_string());
+        assert_eq!(session.active_profiles, vec!["rust".to_string()]);
+    }
+
+    #[test]
+    fn test_is_active() {
+        let session = Session {
+            active_profiles: vec!["git".to_string()],
+        };
+        assert!(session.is_active("git"));
+        assert!(!session.is_active("rust"));
+    }
+
+    #[test]
+    fn test_activation_order() {
+        let session = Session {
+            active_profiles: vec!["git".to_string(), "rust".to_string(), "node".to_string()],
+        };
+        assert_eq!(session.activation_order("git"), Some(1));
+        assert_eq!(session.activation_order("rust"), Some(2));
+        assert_eq!(session.activation_order("node"), Some(3));
+        assert_eq!(session.activation_order("python"), None);
+    }
+
+    #[test]
+    fn test_use_profile_at_inserts_at_position() {
+        let mut session = Session {
+            active_profiles: vec!["git".to_string(), "rust".to_string()],
+        };
+        session.use_profile_at("node".to_string(), 1);
+        assert_eq!(
+            session.active_profiles,
+            vec!["node".to_string(), "git".to_string(), "rust".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_use_profile_at_repositions_existing() {
+        let mut session = Session {
+            active_profiles: vec!["git".to_string(), "rust".to_string(), "node".to_string()],
+        };
+        session.use_profile_at("node".to_string(), 1);
+        assert_eq!(
+            session.active_profiles,
+            vec!["node".to_string(), "git".to_string(), "rust".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_use_profile_at_clamps_to_end() {
+        let mut session = Session {
+            active_profiles: vec!["git".to_string()],
+        };
+        session.use_profile_at("rust".to_string(), 100);
+        assert_eq!(
+            session.active_profiles,
+            vec!["git".to_string(), "rust".to_string()]
+        );
+    }
+}

--- a/crates/am/src/update.rs
+++ b/crates/am/src/update.rs
@@ -556,7 +556,10 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                 .remove_profile(&name)
                 .map_err(|e| UpdateError::Other(e.to_string()))?;
             model.session.active_profiles.retain(|p| p != &name);
-            Ok(UpdateResult::with_effects(&[Effect::SaveProfiles, Effect::SaveSession]))
+            Ok(UpdateResult::with_effects(&[
+                Effect::SaveProfiles,
+                Effect::SaveSession,
+            ]))
         }
         Message::Import(payload) => {
             let mut effects = Vec::new();
@@ -638,7 +641,10 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                     *p = new_name.clone();
                 }
             }
-            Ok(UpdateResult::with_effects(&[Effect::SaveProfiles, Effect::SaveSession]))
+            Ok(UpdateResult::with_effects(&[
+                Effect::SaveProfiles,
+                Effect::SaveSession,
+            ]))
         }
     }
 }

--- a/crates/am/src/update.rs
+++ b/crates/am/src/update.rs
@@ -7,7 +7,7 @@ use crate::init::{generate_init, generate_reload};
 use crate::project::ProjectAliases;
 use crate::security::{SecurityConfig, TrustStatus};
 use crate::trust::ProjectTrust;
-use crate::{profile, AliasSet, AliasTarget, Message, Profile, ProfileConfig};
+use crate::{profile, AliasSet, AliasTarget, Message, Profile, ProfileConfig, Session};
 
 pub struct UpdateResult {
     pub next: Option<Message>,
@@ -53,6 +53,7 @@ impl UpdateResult {
 
 pub struct AppModel {
     pub config: Config,
+    pub session: Session,
     pub cwd: std::path::PathBuf,
     config_dir: PathBuf,
     profile_config: ProfileConfig,
@@ -85,12 +86,14 @@ impl Default for AppModel {
 impl AppModel {
     fn load_from_internal(config_dir: PathBuf) -> Self {
         let config = Config::load_from(&config_dir).unwrap_or_default();
+        let session = Session::load_from(&config_dir).unwrap_or_default();
         let profile_config = ProfileConfig::load_from(&config_dir).unwrap_or_default();
         let mut security_config = SecurityConfig::load_from(&config_dir).unwrap_or_default();
         let cwd = std::env::current_dir().unwrap_or_default();
         let project_trust = resolve_project_trust(&cwd, &mut security_config);
         Self {
             config,
+            session,
             cwd,
             config_dir,
             profile_config,
@@ -111,6 +114,7 @@ impl AppModel {
     pub fn new(config: Config, profile_config: ProfileConfig) -> Self {
         Self {
             config,
+            session: Session::default(),
             cwd: std::env::current_dir().unwrap_or_default(),
             config_dir: PathBuf::new(),
             profile_config,
@@ -126,6 +130,7 @@ impl AppModel {
     ) -> Self {
         Self {
             config,
+            session: Session::default(),
             cwd: std::env::current_dir().unwrap_or_default(),
             config_dir: PathBuf::new(),
             profile_config,
@@ -195,7 +200,7 @@ impl AppModel {
     }
 
     pub fn get_active_profiles(&self) -> Vec<&Profile> {
-        self.config
+        self.session
             .active_profiles
             .iter()
             .filter_map(|name| self.profile_config.get_profile_by_name(name))
@@ -207,6 +212,13 @@ impl AppModel {
             return Ok(());
         }
         self.config.save_to(&self.config_dir)
+    }
+
+    pub fn save_session(&self) -> crate::Result<()> {
+        if self.config_dir.as_os_str().is_empty() {
+            return Ok(());
+        }
+        self.session.save_to(&self.config_dir)
     }
 
     pub fn save_profiles(&self) -> crate::Result<()> {
@@ -300,7 +312,7 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                     raw,
                 }))
             }
-            AliasTarget::ActiveProfile if model.config.active_profiles.is_empty() => {
+            AliasTarget::ActiveProfile if model.session.active_profiles.is_empty() => {
                 if model.project_path().is_some() {
                     if let Some(trust) = model.project_trust() {
                         if !trust.is_trusted() {
@@ -345,7 +357,7 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                 }
                 Ok(UpdateResult::effect(Effect::RemoveLocalAlias { name }))
             }
-            AliasTarget::ActiveProfile if model.config.active_profiles.is_empty() => {
+            AliasTarget::ActiveProfile if model.session.active_profiles.is_empty() => {
                 if model.project_path().is_some() {
                     if let Some(trust) = model.project_trust() {
                         if !trust.is_trusted() {
@@ -425,7 +437,7 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
             let output = render_listing(
                 &model.config.aliases,
                 model.profile_config(),
-                &model.config.active_profiles,
+                &model.session.active_profiles,
                 model.project_trust(),
             );
             println!("{output}");
@@ -437,14 +449,14 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
             .map_err(|e| UpdateError::Other(e.to_string()))?
         {
             profile::Response::ProfileAdded(_) => {
-                if !model.config.active_profiles.contains(&name) {
-                    model.config.active_profiles.push(name);
+                if !model.session.active_profiles.contains(&name) {
+                    model.session.active_profiles.push(name);
                 }
                 Ok(UpdateResult::effect(Effect::SaveProfiles))
             }
             profile::Response::ProfileActivated(_) => {
-                if !model.config.active_profiles.contains(&name) {
-                    model.config.active_profiles.push(name);
+                if !model.session.active_profiles.contains(&name) {
+                    model.session.active_profiles.push(name);
                 }
                 Ok(UpdateResult::done())
             }
@@ -452,7 +464,7 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
         Message::InitShell(shell) => {
             let resolved = model
                 .profile_config()
-                .resolve_active_aliases(&model.config.active_profiles);
+                .resolve_active_aliases(&model.session.active_profiles);
             let output = generate_init(&shell, &model.config.aliases, &resolved);
             print!("{output}");
             Ok(UpdateResult::done())
@@ -460,7 +472,7 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
         Message::Reload(shell) => {
             let resolved = model
                 .profile_config()
-                .resolve_active_aliases(&model.config.active_profiles);
+                .resolve_active_aliases(&model.session.active_profiles);
             let prev = std::env::var("_AM_ALIASES").ok();
             let output = generate_reload(&shell, &model.config.aliases, &resolved, prev.as_deref());
             if !output.is_empty() {
@@ -496,13 +508,13 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
             }
             let mut effects = Vec::new();
             for name in names {
-                let was_active = model.config.is_active(&name);
+                let was_active = model.session.is_active(&name);
                 let alias_count = model
                     .profile_config()
                     .get_profile_by_name(&name)
                     .map(|p| p.aliases.iter().count())
                     .unwrap_or(0);
-                model.config.toggle_profile(name.clone());
+                model.session.toggle_profile(name.clone());
                 let (action, verb) = if was_active {
                     ("deactivated", "unloaded")
                 } else {
@@ -512,7 +524,7 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                     "{name} {action}, {alias_count} aliases {verb}"
                 )));
             }
-            effects.push(Effect::SaveConfig);
+            effects.push(Effect::SaveSession);
             Ok(UpdateResult::with_effects(&effects))
         }
         Message::UseProfilesAt(names, priority) => {
@@ -529,13 +541,13 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                     .get_profile_by_name(&name)
                     .map(|p| p.aliases.iter().count())
                     .unwrap_or(0);
-                model.config.use_profile_at(name.clone(), priority + i);
+                model.session.use_profile_at(name.clone(), priority + i);
                 effects.push(Effect::Print(format!(
                     "{name} activated at position {}, {alias_count} aliases loaded",
                     priority + i
                 )));
             }
-            effects.push(Effect::SaveConfig);
+            effects.push(Effect::SaveSession);
             Ok(UpdateResult::with_effects(&effects))
         }
         Message::RemoveProfile(name) => {
@@ -543,8 +555,8 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                 .profile_config_mut()
                 .remove_profile(&name)
                 .map_err(|e| UpdateError::Other(e.to_string()))?;
-            model.config.active_profiles.retain(|p| p != &name);
-            Ok(UpdateResult::effect(Effect::SaveProfiles))
+            model.session.active_profiles.retain(|p| p != &name);
+            Ok(UpdateResult::with_effects(&[Effect::SaveProfiles, Effect::SaveSession]))
         }
         Message::Import(payload) => {
             let mut effects = Vec::new();
@@ -621,12 +633,12 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                     name: old_name.clone(),
                 })?;
             profile.name = new_name.clone();
-            for p in &mut model.config.active_profiles {
+            for p in &mut model.session.active_profiles {
                 if *p == old_name {
                     *p = new_name.clone();
                 }
             }
-            Ok(UpdateResult::effect(Effect::SaveProfiles))
+            Ok(UpdateResult::with_effects(&[Effect::SaveProfiles, Effect::SaveSession]))
         }
     }
 }
@@ -644,7 +656,7 @@ fn resolve_profile_mut<'a>(
             }),
         AliasTarget::ActiveProfile => {
             let active = model
-                .config
+                .session
                 .active_profiles
                 .last()
                 .cloned()
@@ -962,9 +974,9 @@ mod tests {
         assert!(
             matches!(&result.effects[0], Effect::Print(s) if s.contains("git") && s.contains("activated"))
         );
-        assert!(matches!(&result.effects[2], Effect::SaveConfig));
+        assert!(matches!(&result.effects[2], Effect::SaveSession));
         assert_eq!(
-            model.config.active_profiles,
+            model.session.active_profiles,
             vec!["git".to_string(), "rust".to_string()]
         );
     }
@@ -983,7 +995,7 @@ mod tests {
 
         assert!(matches!(result, Err(UpdateError::ProfileNotFound { name }) if name == "nope"));
         // git should NOT have been toggled since validation failed
-        assert!(model.config.active_profiles.is_empty());
+        assert!(model.session.active_profiles.is_empty());
     }
 
     #[test]
@@ -1008,24 +1020,21 @@ mod tests {
         assert!(
             matches!(&result.effects[1], Effect::Print(s) if s.contains("rust") && s.contains("position 2"))
         );
-        assert!(matches!(&result.effects[2], Effect::SaveConfig));
+        assert!(matches!(&result.effects[2], Effect::SaveSession));
         assert_eq!(
-            model.config.active_profiles,
+            model.session.active_profiles,
             vec!["git".to_string(), "rust".to_string()]
         );
     }
 
     #[test]
     fn use_profiles_at_inserts_at_offset() {
-        let config = Config {
-            active_profiles: vec!["node".to_string()],
-            ..Config::default()
-        };
         let profile_config: ProfileConfig = toml::from_str(
             "[[profiles]]\nname = \"git\"\n\n[[profiles]]\nname = \"rust\"\n\n[[profiles]]\nname = \"node\"\n",
         )
         .unwrap();
-        let mut model = AppModel::new(config, profile_config);
+        let mut model = AppModel::new(Config::default(), profile_config);
+        model.session.active_profiles = vec!["node".to_string()];
 
         let result = update(
             &mut model,
@@ -1034,10 +1043,10 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.effects.len(), 3);
-        assert!(matches!(&result.effects[2], Effect::SaveConfig));
+        assert!(matches!(&result.effects[2], Effect::SaveSession));
         // node at 1, git at 2, rust at 3
         assert_eq!(
-            model.config.active_profiles,
+            model.session.active_profiles,
             vec!["node".to_string(), "git".to_string(), "rust".to_string()]
         );
     }
@@ -1055,7 +1064,7 @@ mod tests {
         );
 
         assert!(result.is_err());
-        assert!(model.config.active_profiles.is_empty());
+        assert!(model.session.active_profiles.is_empty());
     }
 
     #[test]
@@ -1416,15 +1425,12 @@ mod tests {
 
     #[test]
     fn rename_profile_renames_in_config_and_active_list() {
-        let config = Config {
-            active_profiles: vec!["git".to_string()],
-            ..Config::default()
-        };
         let profile_config: ProfileConfig = toml::from_str(
             "[[profiles]]\nname = \"git\"\n[profiles.aliases]\ngs = \"git status\"\n",
         )
         .unwrap();
-        let mut model = AppModel::new(config, profile_config);
+        let mut model = AppModel::new(Config::default(), profile_config);
+        model.session.active_profiles = vec!["git".to_string()];
 
         let result = update(
             &mut model,
@@ -1435,11 +1441,14 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(result.effects, vec![Effect::SaveProfiles]);
+        assert_eq!(
+            result.effects,
+            vec![Effect::SaveProfiles, Effect::SaveSession]
+        );
         assert!(model.profile_config().get_profile_by_name("vcs").is_some());
         assert!(model.profile_config().get_profile_by_name("git").is_none());
-        assert!(model.config.active_profiles.contains(&"vcs".to_string()));
-        assert!(!model.config.active_profiles.contains(&"git".to_string()));
+        assert!(model.session.active_profiles.contains(&"vcs".to_string()));
+        assert!(!model.session.active_profiles.contains(&"git".to_string()));
         // Aliases preserved
         let profile = model.profile_config().get_profile_by_name("vcs").unwrap();
         let key = crate::AliasName::from("gs");


### PR DESCRIPTION
- users managing dotfiles with Nix Home Manager or GNU Stow symlink config files to read-only locations; writing `active_profiles` back to `config.toml` on every profile switch breaks this workflow
- move `active_profiles` out of `config.toml` into a new `session.toml`; introduce `Session` struct and `Effect::SaveSession`
- profile activation/toggle/rename/remove now emit `SaveSession`; global alias mutations still emit `SaveConfig`
- no migration: existing `active_profiles` in `config.toml` is silently ignored on upgrade

Closes #86