### PR TITLE
fix(am): add --local/-l flag to am remove

### DIFF
--- a/completions/bash/am.bash
+++ b/completions/bash/am.bash
@@ -777,7 +777,7 @@ _am() {
             return 0
             ;;
         am__remove)
-            opts="-p -g -h -V --profile --global --sub --help --version <NAME>"
+            opts="-p -l -g -h -V --profile --local --global --sub --help --version <NAME>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/fish/am.fish
+++ b/completions/fish/am.fish
@@ -52,6 +52,7 @@ complete -c am -n "__fish_am_using_subcommand add" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand add" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand remove" -s p -l profile -d 'Profile to remove the alias from (defaults to active profile)' -r
 complete -c am -n "__fish_am_using_subcommand remove" -l sub -d 'Subcommand path segments to complete the key (e.g. --sub b --sub l removes jj:b:l)' -r
+complete -c am -n "__fish_am_using_subcommand remove" -s l -l local -d 'Remove from the project\'s .aliases file instead of a profile'
 complete -c am -n "__fish_am_using_subcommand remove" -s g -l global -d 'Remove a global alias'
 complete -c am -n "__fish_am_using_subcommand remove" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand remove" -s V -l version -d 'Print version'

--- a/completions/powershell/_am.ps1
+++ b/completions/powershell/_am.ps1
@@ -63,6 +63,8 @@ Register-ArgumentCompleter -Native -CommandName 'am' -ScriptBlock {
             [CompletionResult]::new('-p', '-p', [CompletionResultType]::ParameterName, 'Profile to remove the alias from (defaults to active profile)')
             [CompletionResult]::new('--profile', '--profile', [CompletionResultType]::ParameterName, 'Profile to remove the alias from (defaults to active profile)')
             [CompletionResult]::new('--sub', '--sub', [CompletionResultType]::ParameterName, 'Subcommand path segments to complete the key (e.g. --sub b --sub l removes jj:b:l)')
+            [CompletionResult]::new('-l', '-l', [CompletionResultType]::ParameterName, 'Remove from the project''s .aliases file instead of a profile')
+            [CompletionResult]::new('--local', '--local', [CompletionResultType]::ParameterName, 'Remove from the project''s .aliases file instead of a profile')
             [CompletionResult]::new('-g', '-g', [CompletionResultType]::ParameterName, 'Remove a global alias')
             [CompletionResult]::new('--global', '--global', [CompletionResultType]::ParameterName, 'Remove a global alias')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')

--- a/completions/zsh/_am
+++ b/completions/zsh/_am
@@ -48,9 +48,11 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (remove)
 _arguments "${_arguments_options[@]}" : \
-'(-g --global)-p+[Profile to remove the alias from (defaults to active profile)]:PROFILE:_default' \
-'(-g --global)--profile=[Profile to remove the alias from (defaults to active profile)]:PROFILE:_default' \
+'(-l --local -g --global)-p+[Profile to remove the alias from (defaults to active profile)]:PROFILE:_default' \
+'(-l --local -g --global)--profile=[Profile to remove the alias from (defaults to active profile)]:PROFILE:_default' \
 '*--sub=[Subcommand path segments to complete the key (e.g. --sub b --sub l removes jj\:b\:l)]:SUB:_default' \
+'(-g --global)-l[Remove from the project'\''s .aliases file instead of a profile]' \
+'(-g --global)--local[Remove from the project'\''s .aliases file instead of a profile]' \
 '-g[Remove a global alias]' \
 '--global[Remove a global alias]' \
 '-h[Print help]' \

--- a/crates/am/src/bin/am.rs
+++ b/crates/am/src/bin/am.rs
@@ -112,12 +112,15 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::Remove {
             profile,
+            local,
             global,
             name,
             sub,
         } => {
             let target = if *global {
                 AliasTarget::Global
+            } else if *local {
+                AliasTarget::Local
             } else {
                 profile
                     .as_deref()

--- a/crates/am/src/cli.rs
+++ b/crates/am/src/cli.rs
@@ -25,8 +25,12 @@ pub enum Commands {
     #[command(alias = "r")]
     Remove {
         /// Profile to remove the alias from (defaults to active profile)
-        #[arg(short, long, conflicts_with = "global")]
+        #[arg(short, long, conflicts_with_all = ["local", "global"])]
         profile: Option<String>,
+
+        /// Remove from the project's .aliases file instead of a profile
+        #[arg(short, long, conflicts_with = "global")]
+        local: bool,
 
         /// Remove a global alias
         #[arg(short, long)]

--- a/crates/am/src/hook.rs
+++ b/crates/am/src/hook.rs
@@ -562,7 +562,10 @@ mod tests {
 
         // First run: load c:l, c wrapper is emitted
         let (output, _) = t.run(&Shells::Fish, &cwd, None);
-        assert!(output.contains("function c"), "first run should emit c wrapper");
+        assert!(
+            output.contains("function c"),
+            "first run should emit c wrapper"
+        );
         assert!(output.contains("clippy"));
 
         // Add c:t — the .aliases file changes, but program name `c` stays the same
@@ -575,7 +578,10 @@ mod tests {
             "hook must re-emit c wrapper after new subcommand added, got: {output}"
         );
         assert!(output.contains("test"), "updated wrapper must include c:t");
-        assert!(output.contains("clippy"), "updated wrapper must still include c:l");
+        assert!(
+            output.contains("clippy"),
+            "updated wrapper must still include c:l"
+        );
     }
 
     #[test]

--- a/crates/am/src/hook.rs
+++ b/crates/am/src/hook.rs
@@ -59,10 +59,13 @@ pub fn generate_hook_with_security(
     // repeating warnings. It is passed in explicitly rather than read from the
     // environment so that callers (e.g. tests) can control it independently.
 
-    // Helper: generate unalias commands for previously loaded aliases
+    // Helper: unalias only shell-level names (no `:` — subcommand keys like `c:l`
+    // are tracked for change detection but are not themselves shell functions).
     let unload_prev = |lines: &mut Vec<String>| {
         for name in &prev {
-            lines.push(shell_impl.unalias(name));
+            if !name.contains(':') {
+                lines.push(shell_impl.unalias(name));
+            }
         }
     };
 
@@ -93,16 +96,25 @@ pub fn generate_hook_with_security(
 
                         let subcmd_groups =
                             crate::subcommand::group_by_program(&project.subcommands);
+
+                        // all_names tracks both the shell-level wrapper names (e.g. `c`) and
+                        // the individual subcommand keys (e.g. `c:l`, `c:t`). Wrapper names
+                        // are used to unload old functions; subcommand keys make change
+                        // detection precise — adding c:t when c:l already exists would
+                        // otherwise appear identical (both produce program name `c`).
                         let subcmd_program_names: Vec<String> =
                             subcmd_groups.keys().cloned().collect();
+                        let subcmd_keys: Vec<String> =
+                            project.subcommands.keys().cloned().collect();
 
                         let mut all_names: Vec<String> = names.clone();
                         all_names.extend(subcmd_program_names.clone());
+                        all_names.extend(subcmd_keys);
                         all_names.sort();
                         all_names.dedup();
 
-                        // If the same aliases are already loaded, skip entirely.
-                        // The hash check guarantees commands haven't changed either.
+                        // If the exact same set of aliases and subcommand keys is already
+                        // loaded, skip entirely — nothing changed.
                         if all_names.len() == prev.len()
                             && all_names.iter().zip(&prev).all(|(a, b)| a == b)
                         {
@@ -533,6 +545,37 @@ mod tests {
             !output.contains("am: loaded"),
             "should not show load message for parent .aliases, got: {output}"
         );
+    }
+
+    #[test]
+    fn test_hook_picks_up_new_subcommand_added_to_existing_program() {
+        // Regression: when a second subcommand is added under the same program (e.g. c:t after
+        // c:l), the hook was incorrectly skipping the reload because the set of *program names*
+        // hadn't changed ("c" was already in _AM_PROJECT_ALIASES). The wrapper function must
+        // be regenerated whenever the file content changes.
+        let mut t = TestBed::new()
+            .with_aliases("[subcommands]\n\"c:l\" = [\"clippy\"]\n")
+            .with_security_trusted()
+            .setup();
+
+        let cwd = t.root();
+
+        // First run: load c:l, c wrapper is emitted
+        let (output, _) = t.run(&Shells::Fish, &cwd, None);
+        assert!(output.contains("function c"), "first run should emit c wrapper");
+        assert!(output.contains("clippy"));
+
+        // Add c:t — the .aliases file changes, but program name `c` stays the same
+        t.update_aliases("[subcommands]\n\"c:l\" = [\"clippy\"]\n\"c:t\" = [\"test\"]\n");
+
+        // Second run: prev="c" (already loaded), but file has new content
+        let (output, _) = t.run(&Shells::Fish, &cwd, Some("c"));
+        assert!(
+            output.contains("function c"),
+            "hook must re-emit c wrapper after new subcommand added, got: {output}"
+        );
+        assert!(output.contains("test"), "updated wrapper must include c:t");
+        assert!(output.contains("clippy"), "updated wrapper must still include c:l");
     }
 
     #[test]

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_bash_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_bash_simple_profile.snap
@@ -834,7 +834,7 @@ _am() {
             return 0
             ;;
         am__remove)
-            opts="-p -g -h -V --profile --global --sub --help --version <NAME>"
+            opts="-p -l -g -h -V --profile --local --global --sub --help --version <NAME>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_bash_with_kubectl_subcommands.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_bash_with_kubectl_subcommands.snap
@@ -862,7 +862,7 @@ _am() {
             return 0
             ;;
         am__remove)
-            opts="-p -g -h -V --profile --global --sub --help --version <NAME>"
+            opts="-p -l -g -h -V --profile --local --global --sub --help --version <NAME>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_deep_chain.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_deep_chain.snap
@@ -106,6 +106,7 @@ complete -c am -n "__fish_am_using_subcommand add" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand add" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand remove" -s p -l profile -d 'Profile to remove the alias from (defaults to active profile)' -r
 complete -c am -n "__fish_am_using_subcommand remove" -l sub -d 'Subcommand path segments to complete the key (e.g. --sub b --sub l removes jj:b:l)' -r
+complete -c am -n "__fish_am_using_subcommand remove" -s l -l local -d 'Remove from the project\'s .aliases file instead of a profile'
 complete -c am -n "__fish_am_using_subcommand remove" -s g -l global -d 'Remove a global alias'
 complete -c am -n "__fish_am_using_subcommand remove" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand remove" -s V -l version -d 'Print version'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_globals_and_multi_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_globals_and_multi_profile.snap
@@ -109,6 +109,7 @@ complete -c am -n "__fish_am_using_subcommand add" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand add" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand remove" -s p -l profile -d 'Profile to remove the alias from (defaults to active profile)' -r
 complete -c am -n "__fish_am_using_subcommand remove" -l sub -d 'Subcommand path segments to complete the key (e.g. --sub b --sub l removes jj:b:l)' -r
+complete -c am -n "__fish_am_using_subcommand remove" -s l -l local -d 'Remove from the project\'s .aliases file instead of a profile'
 complete -c am -n "__fish_am_using_subcommand remove" -s g -l global -d 'Remove a global alias'
 complete -c am -n "__fish_am_using_subcommand remove" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand remove" -s V -l version -d 'Print version'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_multi_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_multi_profile.snap
@@ -108,6 +108,7 @@ complete -c am -n "__fish_am_using_subcommand add" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand add" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand remove" -s p -l profile -d 'Profile to remove the alias from (defaults to active profile)' -r
 complete -c am -n "__fish_am_using_subcommand remove" -l sub -d 'Subcommand path segments to complete the key (e.g. --sub b --sub l removes jj:b:l)' -r
+complete -c am -n "__fish_am_using_subcommand remove" -s l -l local -d 'Remove from the project\'s .aliases file instead of a profile'
 complete -c am -n "__fish_am_using_subcommand remove" -s g -l global -d 'Remove a global alias'
 complete -c am -n "__fish_am_using_subcommand remove" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand remove" -s V -l version -d 'Print version'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_simple_profile.snap
@@ -105,6 +105,7 @@ complete -c am -n "__fish_am_using_subcommand add" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand add" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand remove" -s p -l profile -d 'Profile to remove the alias from (defaults to active profile)' -r
 complete -c am -n "__fish_am_using_subcommand remove" -l sub -d 'Subcommand path segments to complete the key (e.g. --sub b --sub l removes jj:b:l)' -r
+complete -c am -n "__fish_am_using_subcommand remove" -s l -l local -d 'Remove from the project\'s .aliases file instead of a profile'
 complete -c am -n "__fish_am_using_subcommand remove" -s g -l global -d 'Remove a global alias'
 complete -c am -n "__fish_am_using_subcommand remove" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand remove" -s V -l version -d 'Print version'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_globals.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_globals.snap
@@ -105,6 +105,7 @@ complete -c am -n "__fish_am_using_subcommand add" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand add" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand remove" -s p -l profile -d 'Profile to remove the alias from (defaults to active profile)' -r
 complete -c am -n "__fish_am_using_subcommand remove" -l sub -d 'Subcommand path segments to complete the key (e.g. --sub b --sub l removes jj:b:l)' -r
+complete -c am -n "__fish_am_using_subcommand remove" -s l -l local -d 'Remove from the project\'s .aliases file instead of a profile'
 complete -c am -n "__fish_am_using_subcommand remove" -s g -l global -d 'Remove a global alias'
 complete -c am -n "__fish_am_using_subcommand remove" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand remove" -s V -l version -d 'Print version'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_simple_subcommands.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_simple_subcommands.snap
@@ -114,6 +114,7 @@ complete -c am -n "__fish_am_using_subcommand add" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand add" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand remove" -s p -l profile -d 'Profile to remove the alias from (defaults to active profile)' -r
 complete -c am -n "__fish_am_using_subcommand remove" -l sub -d 'Subcommand path segments to complete the key (e.g. --sub b --sub l removes jj:b:l)' -r
+complete -c am -n "__fish_am_using_subcommand remove" -s l -l local -d 'Remove from the project\'s .aliases file instead of a profile'
 complete -c am -n "__fish_am_using_subcommand remove" -s g -l global -d 'Remove a global alias'
 complete -c am -n "__fish_am_using_subcommand remove" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand remove" -s V -l version -d 'Print version'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
@@ -132,6 +132,8 @@ Register-ArgumentCompleter -Native -CommandName 'am' -ScriptBlock {
             [System.Management.Automation.CompletionResult]::new('-p', '-p', [System.Management.Automation.CompletionResultType]::ParameterName, 'Profile to remove the alias from (defaults to active profile)')
             [System.Management.Automation.CompletionResult]::new('--profile', '--profile', [System.Management.Automation.CompletionResultType]::ParameterName, 'Profile to remove the alias from (defaults to active profile)')
             [System.Management.Automation.CompletionResult]::new('--sub', '--sub', [System.Management.Automation.CompletionResultType]::ParameterName, 'Subcommand path segments to complete the key (e.g. --sub b --sub l removes jj:b:l)')
+            [System.Management.Automation.CompletionResult]::new('-l', '-l', [System.Management.Automation.CompletionResultType]::ParameterName, 'Remove from the project''s .aliases file instead of a profile')
+            [System.Management.Automation.CompletionResult]::new('--local', '--local', [System.Management.Automation.CompletionResultType]::ParameterName, 'Remove from the project''s .aliases file instead of a profile')
             [System.Management.Automation.CompletionResult]::new('-g', '-g', [System.Management.Automation.CompletionResultType]::ParameterName, 'Remove a global alias')
             [System.Management.Automation.CompletionResult]::new('--global', '--global', [System.Management.Automation.CompletionResultType]::ParameterName, 'Remove a global alias')
             [System.Management.Automation.CompletionResult]::new('-h', '-h', [System.Management.Automation.CompletionResultType]::ParameterName, 'Print help')

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_zsh_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_zsh_simple_profile.snap
@@ -86,9 +86,11 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (remove)
 _arguments "${_arguments_options[@]}" : \
-'(-g --global)-p+[Profile to remove the alias from (defaults to active profile)]:PROFILE:_default' \
-'(-g --global)--profile=[Profile to remove the alias from (defaults to active profile)]:PROFILE:_default' \
+'(-l --local -g --global)-p+[Profile to remove the alias from (defaults to active profile)]:PROFILE:_default' \
+'(-l --local -g --global)--profile=[Profile to remove the alias from (defaults to active profile)]:PROFILE:_default' \
 '*--sub=[Subcommand path segments to complete the key (e.g. --sub b --sub l removes jj\:b\:l)]:SUB:_default' \
+'(-g --global)-l[Remove from the project'\''s .aliases file instead of a profile]' \
+'(-g --global)--local[Remove from the project'\''s .aliases file instead of a profile]' \
 '-g[Remove a global alias]' \
 '--global[Remove a global alias]' \
 '-h[Print help]' \


### PR DESCRIPTION
## Summary

- `am remove` was missing the `-l`/`--local` flag that `am add` already had
- Adds `--local` to the CLI struct with `conflicts_with = "global"` and fixes `--profile` to conflict with both `--local` and `--global`
- Wires `AliasTarget::Local` into the remove path in `am.rs`
- Updates shell completions (bash, fish, zsh, powershell) and regenerates all affected snapshots

Closes #89