### PR TITLE
fix(shell): resolve function/alias shadowing for zsh and bash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,10 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: prime zsh env for alias scan tests
+        if: runner.os != 'Windows'
+        shell: bash
+        run: echo "alias la='ls -lAh'" >> ~/.zshrc
       - name: cargo test
         shell: bash
         run: cargo test --verbose --all --locked

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,9 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: install zsh (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y zsh
       - name: prime zsh env for alias scan tests
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,14 +94,21 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.9
       - name: install zsh (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y zsh
-      - name: prime zsh env for alias scan tests
+        run: sudo apt-get update -y && sudo apt-get install -y zsh
+      - name: prime zsh env for e2e tests
         if: runner.os != 'Windows'
         shell: bash
         run: echo "alias la='ls -lAh'" >> ~/.zshrc
       - name: cargo test
         shell: bash
         run: cargo test --verbose --all --locked
+        env:
+          RUST_LOG: debug
+          RUST_BACKTRACE: full
+      - name: e2e tests
+        if: runner.os != 'Windows'
+        shell: bash
+        run: cargo test --verbose --locked --test e2e -- --ignored
         env:
           RUST_LOG: debug
           RUST_BACKTRACE: full

--- a/crates/am-tui/src/update/text_input.rs
+++ b/crates/am-tui/src/update/text_input.rs
@@ -42,10 +42,8 @@ use amoxide::AliasName;
 
 pub fn handle(model: &mut TuiModel, msg: TuiMessage) {
     match msg {
-        TuiMessage::StartCreateProfile => {
-            if model.mode == Mode::Normal {
-                model.mode = Mode::TextInput(TextInputState::NewProfile(String::new()));
-            }
+        TuiMessage::StartCreateProfile if model.mode == Mode::Normal => {
+            model.mode = Mode::TextInput(TextInputState::NewProfile(String::new()));
         }
         TuiMessage::StartAddAlias => {
             if model.mode != Mode::Normal {

--- a/crates/am-tui/src/update/transfer.rs
+++ b/crates/am-tui/src/update/transfer.rs
@@ -49,8 +49,7 @@ pub fn handle(model: &mut TuiModel, msg: TuiMessage) {
             model.active_column = Column::Left;
         }
         TuiMessage::ExecuteTransfer
-            if matches!(model.mode, Mode::Transfer(_))
-                && model.active_column == Column::Right =>
+            if matches!(model.mode, Mode::Transfer(_)) && model.active_column == Column::Right =>
         {
             execute_transfer(model);
         }

--- a/crates/am-tui/src/update/transfer.rs
+++ b/crates/am-tui/src/update/transfer.rs
@@ -48,10 +48,11 @@ pub fn handle(model: &mut TuiModel, msg: TuiMessage) {
             model.mode = Mode::Normal;
             model.active_column = Column::Left;
         }
-        TuiMessage::ExecuteTransfer => {
-            if matches!(model.mode, Mode::Transfer(_)) && model.active_column == Column::Right {
-                execute_transfer(model);
-            }
+        TuiMessage::ExecuteTransfer
+            if matches!(model.mode, Mode::Transfer(_))
+                && model.active_column == Column::Right =>
+        {
+            execute_transfer(model);
         }
         _ => {}
     }

--- a/crates/am/src/bin/am.rs
+++ b/crates/am/src/bin/am.rs
@@ -7,6 +7,7 @@ use amoxide::{
     cli::*,
     dirs::relative_path,
     effects::Effect,
+    env_vars,
     exchange::{render_suspicious_warning, scan_suspicious, ExportAll},
     import_export::{handle_export, handle_import, handle_share},
     profile::AliasCollection,
@@ -31,6 +32,16 @@ fn setup_logging() {
 }
 
 fn main() -> anyhow::Result<()> {
+    // Guard against recursive invocation during alias scanning.
+    // When `zsh -i -c alias` is spawned to enumerate existing shell aliases it
+    // sources the user's startup files, which call `am hook` (or `am init`).
+    // If those calls were allowed to run normally they could trigger another
+    // scan, causing infinite recursion.  Exiting here makes `eval "$(...)"` a
+    // no-op, which is safe.
+    if std::env::var(env_vars::AM_DETECTING_ALIASES).is_ok() {
+        return Ok(());
+    }
+
     let cli = Cli::parse();
     let mut model = AppModel::default();
 

--- a/crates/am/src/env_vars.rs
+++ b/crates/am/src/env_vars.rs
@@ -1,0 +1,21 @@
+/// Tracks globally-loaded alias names (global + active-profile aliases).
+/// Value: comma-separated list, e.g. `"gs,ll"`.
+pub const AM_ALIASES: &str = "_AM_ALIASES";
+
+/// Tracks project-level alias names loaded by the cd hook.
+/// Value: comma-separated list, e.g. `"b,t"`.
+pub const AM_PROJECT_ALIASES: &str = "_AM_PROJECT_ALIASES";
+
+/// Path of the `.aliases` file currently in scope, used to suppress
+/// duplicate hook messages when navigating into subdirectories.
+pub const AM_PROJECT_PATH: &str = "_AM_PROJECT_PATH";
+
+/// Set during `zsh -i -c alias` alias-detection scans to prevent recursive
+/// `am` invocations from triggering another scan.  When present, the `am`
+/// binary exits immediately with no output so that `eval "$(...)"` in shell
+/// startup scripts is a no-op.
+pub const AM_DETECTING_ALIASES: &str = "_AM_DETECTING_ALIASES";
+
+/// Legacy tracking variable replaced by `AM_ALIASES`.  Unset on startup so
+/// that old installations do not leave stale state.
+pub const AM_PROFILE_ALIASES_LEGACY: &str = "_AM_PROFILE_ALIASES";

--- a/crates/am/src/hook.rs
+++ b/crates/am/src/hook.rs
@@ -294,6 +294,7 @@ mod tests {
                 shell,
                 cfg: &cfg,
                 cwd,
+                external_aliases: Default::default(),
             };
             generate_hook_with_security(&ctx, prev, None, &mut self.security, false).unwrap()
         }

--- a/crates/am/src/hook.rs
+++ b/crates/am/src/hook.rs
@@ -368,7 +368,7 @@ mod tests {
         let cwd = t.root();
         let (output, _) = t.run(&Shells::Zsh, &cwd, Some("old"));
         assert!(output.contains("unset -f old"));
-        assert!(output.contains("b() { make build \"$@\"; }"));
+        assert!(output.contains("alias b=\"make build\""));
         assert!(output.contains("export _AM_PROJECT_ALIASES="));
     }
 
@@ -425,7 +425,7 @@ mod tests {
         let cwd = t.root();
         let (output, _) = t.run(&Shells::Bash, &cwd, Some("old"));
         assert!(output.contains("unset -f old"));
-        assert!(output.contains("b() { make build \"$@\"; }"));
+        assert!(output.contains("alias b=\"make build\""));
         assert!(output.contains("export _AM_PROJECT_ALIASES="));
     }
 
@@ -598,7 +598,7 @@ mod tests {
 
         let cwd = t.root();
         let (output, _) = t.run(&Shells::Bash, &cwd, None);
-        assert!(output.contains("b() { make build \"$@\"; }"));
+        assert!(output.contains("alias b=\"make build\""));
         assert!(output.contains("jj() {"));
         assert!(output.contains("ab) shift; command jj abandon"));
     }

--- a/crates/am/src/hook.rs
+++ b/crates/am/src/hook.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use crate::env_vars;
 use crate::project::ProjectAliases;
 use crate::security::{SecurityConfig, TrustStatus};
 use crate::shell::ShellContext;
@@ -11,7 +12,7 @@ use crate::trust::{compute_file_hash, render_load_message, render_unload_message
 /// `previous_aliases` — comma-separated alias names from `_AM_PROJECT_ALIASES` env var.
 pub fn generate_hook(ctx: &ShellContext, previous_aliases: Option<&str>) -> crate::Result<String> {
     let mut security = SecurityConfig::load().unwrap_or_default();
-    let prev_project_path = std::env::var("_AM_PROJECT_PATH").ok();
+    let prev_project_path = std::env::var(env_vars::AM_PROJECT_PATH).ok();
     let (output, _changed) = generate_hook_with_security(
         ctx,
         previous_aliases,
@@ -40,7 +41,11 @@ pub fn generate_hook_with_security(
     security_config: &mut SecurityConfig,
     quiet: bool,
 ) -> crate::Result<(String, bool)> {
-    let shell_impl = ctx.shell.clone().as_shell(ctx.cfg);
+    let shell_impl = ctx.shell.clone().as_shell(
+        ctx.cfg,
+        ctx.external_functions.clone(),
+        ctx.external_aliases.clone(),
+    );
     let cwd = ctx.cwd;
     let mut lines: Vec<String> = Vec::new();
     let mut security_changed = false;
@@ -147,7 +152,9 @@ pub fn generate_hook_with_security(
                             lines.push(shell_impl.subcommand_wrapper(program, &base_cmd, entries));
                         }
 
-                        lines.push(shell_impl.set_env("_AM_PROJECT_ALIASES", &all_names.join(",")));
+                        lines.push(
+                            shell_impl.set_env(env_vars::AM_PROJECT_ALIASES, &all_names.join(",")),
+                        );
                     }
                 }
                 TrustStatus::Unknown => {
@@ -175,12 +182,14 @@ pub fn generate_hook_with_security(
             // For non-trusted states: track the path to avoid repeating warnings,
             // and clear the alias tracking env var.
             if !matches!(status, TrustStatus::Trusted) {
-                lines.push(shell_impl.set_env("_AM_PROJECT_PATH", &path.display().to_string()));
+                lines.push(
+                    shell_impl.set_env(env_vars::AM_PROJECT_PATH, &path.display().to_string()),
+                );
                 if !prev.is_empty() {
-                    lines.push(shell_impl.unset_env("_AM_PROJECT_ALIASES"));
+                    lines.push(shell_impl.unset_env(env_vars::AM_PROJECT_ALIASES));
                 }
             } else if prev_project_path.is_some() {
-                lines.push(shell_impl.unset_env("_AM_PROJECT_PATH"));
+                lines.push(shell_impl.unset_env(env_vars::AM_PROJECT_PATH));
             }
         }
         None => {
@@ -189,10 +198,10 @@ pub fn generate_hook_with_security(
                 if !quiet {
                     lines.push(shell_impl.echo(&render_unload_message(&prev)));
                 }
-                lines.push(shell_impl.unset_env("_AM_PROJECT_ALIASES"));
+                lines.push(shell_impl.unset_env(env_vars::AM_PROJECT_ALIASES));
             }
             if prev_project_path.is_some() {
-                lines.push(shell_impl.unset_env("_AM_PROJECT_PATH"));
+                lines.push(shell_impl.unset_env(env_vars::AM_PROJECT_PATH));
             }
         }
     }
@@ -294,6 +303,7 @@ mod tests {
                 shell,
                 cfg: &cfg,
                 cwd,
+                external_functions: Default::default(),
                 external_aliases: Default::default(),
             };
             generate_hook_with_security(&ctx, prev, None, &mut self.security, false).unwrap()
@@ -321,7 +331,7 @@ mod tests {
         let (output, _) = t.run(&Shells::Fish, &cwd, None);
         assert!(output.contains("alias b \"make build\""));
         assert!(output.contains("alias t \"make test\""));
-        assert!(output.contains("_AM_PROJECT_ALIASES"));
+        assert!(output.contains(env_vars::AM_PROJECT_ALIASES));
     }
 
     #[test]
@@ -445,7 +455,7 @@ mod tests {
             "should load aliases from parent .aliases, got: {output}"
         );
         assert!(output.contains("alias t \"make test\""));
-        assert!(output.contains("_AM_PROJECT_ALIASES"));
+        assert!(output.contains(env_vars::AM_PROJECT_ALIASES));
     }
 
     // ─── Trust-gated hook tests ─────────────────────────────────────

--- a/crates/am/src/init.rs
+++ b/crates/am/src/init.rs
@@ -324,8 +324,8 @@ mod tests {
             &aliases,
             &SubcommandSet::new(),
         );
-        assert!(output.contains("gs() { git status \"$@\"; }"));
-        assert!(output.contains("ll() { ls -lha \"$@\"; }"));
+        assert!(output.contains("alias gs=\"git status\""));
+        assert!(output.contains("alias ll=\"ls -lha\""));
     }
 
     #[test]
@@ -396,7 +396,7 @@ mod tests {
             Some("old1"),
         );
         assert!(output.contains("unset -f old1"));
-        assert!(output.contains("gs() { git status \"$@\"; }"));
+        assert!(output.contains("alias gs=\"git status\""));
     }
 
     #[test]
@@ -491,8 +491,8 @@ mod tests {
             &aliases,
             &SubcommandSet::new(),
         );
-        assert!(output.contains("gs() { git status \"$@\"; }"));
-        assert!(output.contains("ll() { ls -lha \"$@\"; }"));
+        assert!(output.contains("alias gs=\"git status\""));
+        assert!(output.contains("alias ll=\"ls -lha\""));
     }
 
     #[test]
@@ -536,7 +536,7 @@ mod tests {
             Some("old1"),
         );
         assert!(output.contains("unset -f old1"));
-        assert!(output.contains("gs() { git status \"$@\"; }"));
+        assert!(output.contains("alias gs=\"git status\""));
     }
 
     #[test]

--- a/crates/am/src/init.rs
+++ b/crates/am/src/init.rs
@@ -240,6 +240,7 @@ mod tests {
             shell,
             cfg: &DEFAULT_CFG,
             cwd: std::path::Path::new("/tmp"),
+            external_aliases: Default::default(),
         }
     }
 
@@ -610,6 +611,7 @@ mod tests {
             shell: &Shells::Fish,
             cfg: &cfg,
             cwd,
+            external_aliases: Default::default(),
         };
         let mut aliases = AliasSet::default();
         aliases.insert(
@@ -631,6 +633,7 @@ mod tests {
             shell: &Shells::Fish,
             cfg: &cfg,
             cwd,
+            external_aliases: Default::default(),
         };
         let output = generate_reload(
             &ctx,

--- a/crates/am/src/init.rs
+++ b/crates/am/src/init.rs
@@ -35,6 +35,25 @@ pub fn generate_init(
     let programs_with_wrappers: std::collections::BTreeSet<&str> =
         subcmd_groups.keys().map(|s| s.as_str()).collect();
 
+    // Preamble: for each am-managed name that already exists in the user's shell
+    // startup environment, emit an explicit cleanup before we define ours.
+    // This prevents pre-existing aliases or functions from shadowing am's native aliases.
+    if !ctx.external_aliases.is_empty() {
+        // Collect all managed names in sorted order for deterministic output.
+        let mut managed: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+        for (alias_name, _) in global_aliases.iter().chain(profile_aliases.iter()) {
+            managed.insert(alias_name.as_ref());
+        }
+        for program in &programs_with_wrappers {
+            managed.insert(program);
+        }
+        for name in &managed {
+            if ctx.external_aliases.contains(*name) {
+                lines.push(shell_impl.unalias(name));
+            }
+        }
+    }
+
     // Emit global aliases (skip those absorbed by subcommand wrappers)
     for (alias_name, alias_value) in global_aliases.iter() {
         let name = alias_name.as_ref();
@@ -620,6 +639,63 @@ mod tests {
         );
         let output = generate_init(&ctx, &AliasSet::default(), &aliases, &SubcommandSet::new());
         assert!(output.contains("abbr --add gs \"git status\""));
+    }
+
+    #[test]
+    fn test_zsh_init_emits_preamble_for_colliding_external_alias() {
+        use std::collections::HashSet;
+        let aliases = test_aliases(); // contains "gs" and "ll"
+        let mut external = HashSet::new();
+        external.insert("gs".to_string()); // only "gs" collides
+
+        let ctx = ShellContext {
+            shell: &Shells::Zsh,
+            cfg: &DEFAULT_CFG,
+            cwd: std::path::Path::new("/tmp"),
+            external_aliases: external,
+        };
+        let output = generate_init(&ctx, &AliasSet::default(), &aliases, &SubcommandSet::new());
+
+        assert!(
+            output.contains("unalias gs 2>/dev/null; unset -f gs 2>/dev/null"),
+            "expected unalias preamble for gs, got:\n{output}"
+        );
+        let preamble_pos = output.find("unalias gs").unwrap();
+        let alias_pos = output.find("alias gs=").unwrap();
+        assert!(preamble_pos < alias_pos, "preamble must appear before alias definition");
+        assert!(!output.contains("unalias ll"), "should not emit preamble for ll");
+    }
+
+    #[test]
+    fn test_zsh_init_no_preamble_when_no_external_aliases() {
+        let aliases = test_aliases();
+        let output = generate_init(
+            &default_ctx(&Shells::Zsh),
+            &AliasSet::default(),
+            &aliases,
+            &SubcommandSet::new(),
+        );
+        assert!(!output.contains("unalias"), "no preamble expected when external_aliases is empty");
+    }
+
+    #[test]
+    fn test_zsh_init_preamble_only_for_managed_names() {
+        use std::collections::HashSet;
+        let mut external = HashSet::new();
+        external.insert("la".to_string());   // am does NOT manage "la"
+        external.insert("gs".to_string());   // am manages "gs"
+
+        let aliases = test_aliases(); // contains "gs" and "ll"
+        let ctx = ShellContext {
+            shell: &Shells::Zsh,
+            cfg: &DEFAULT_CFG,
+            cwd: std::path::Path::new("/tmp"),
+            external_aliases: external,
+        };
+        let output = generate_init(&ctx, &AliasSet::default(), &aliases, &SubcommandSet::new());
+
+        assert!(output.contains("unalias gs 2>/dev/null; unset -f gs 2>/dev/null"));
+        assert!(!output.contains("unalias la"), "must not touch unmanaged external alias");
     }
 
     #[test]

--- a/crates/am/src/init.rs
+++ b/crates/am/src/init.rs
@@ -1,3 +1,4 @@
+use crate::env_vars;
 use crate::shell::{ShellContext, Shells};
 use crate::subcommand::{group_by_program, SubcommandSet};
 use crate::AliasSet;
@@ -26,7 +27,11 @@ pub fn generate_init(
     profile_aliases: &AliasSet,
     subcommands: &SubcommandSet,
 ) -> String {
-    let shell_impl = ctx.shell.clone().as_shell(ctx.cfg);
+    let shell_impl = ctx.shell.clone().as_shell(
+        ctx.cfg,
+        ctx.external_functions.clone(),
+        ctx.external_aliases.clone(),
+    );
     let mut lines: Vec<String> = Vec::new();
     let mut all_names: Vec<String> = Vec::new();
 
@@ -34,25 +39,6 @@ pub fn generate_init(
     let subcmd_groups = group_by_program(subcommands);
     let programs_with_wrappers: std::collections::BTreeSet<&str> =
         subcmd_groups.keys().map(|s| s.as_str()).collect();
-
-    // Preamble: for each am-managed name that already exists in the user's shell
-    // startup environment, emit an explicit cleanup before we define ours.
-    // This prevents pre-existing aliases or functions from shadowing am's native aliases.
-    if !ctx.external_aliases.is_empty() {
-        // Collect all managed names in sorted order for deterministic output.
-        let mut managed: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
-        for (alias_name, _) in global_aliases.iter().chain(profile_aliases.iter()) {
-            managed.insert(alias_name.as_ref());
-        }
-        for program in &programs_with_wrappers {
-            managed.insert(program);
-        }
-        for name in &managed {
-            if ctx.external_aliases.contains(*name) {
-                lines.push(shell_impl.unalias(name));
-            }
-        }
-    }
 
     // Emit global aliases (skip those absorbed by subcommand wrappers)
     for (alias_name, alias_value) in global_aliases.iter() {
@@ -90,10 +76,10 @@ pub fn generate_init(
     if !all_names.is_empty() {
         all_names.sort();
         all_names.dedup();
-        lines.push(shell_impl.set_env("_AM_ALIASES", &all_names.join(",")));
+        lines.push(shell_impl.set_env(env_vars::AM_ALIASES, &all_names.join(",")));
     }
     // Clean up legacy tracking var from older versions
-    lines.push(shell_impl.unset_env("_AM_PROFILE_ALIASES"));
+    lines.push(shell_impl.unset_env(env_vars::AM_PROFILE_ALIASES_LEGACY));
 
     // Wrapper function
     lines.push(String::new());
@@ -119,7 +105,11 @@ pub fn generate_reload(
     subcommands: &SubcommandSet,
     previous_aliases: Option<&str>,
 ) -> String {
-    let shell_impl = ctx.shell.clone().as_shell(ctx.cfg);
+    let shell_impl = ctx.shell.clone().as_shell(
+        ctx.cfg,
+        ctx.external_functions.clone(),
+        ctx.external_aliases.clone(),
+    );
     let mut lines: Vec<String> = Vec::new();
 
     // Unload all previously tracked aliases
@@ -173,12 +163,12 @@ pub fn generate_reload(
     // Update tracking
     if all_names.is_empty() {
         if !prev.is_empty() {
-            lines.push(shell_impl.unset_env("_AM_ALIASES"));
+            lines.push(shell_impl.unset_env(env_vars::AM_ALIASES));
         }
     } else {
         all_names.sort();
         all_names.dedup();
-        lines.push(shell_impl.set_env("_AM_ALIASES", &all_names.join(",")));
+        lines.push(shell_impl.set_env(env_vars::AM_ALIASES, &all_names.join(",")));
     }
 
     lines.join("\n")
@@ -259,6 +249,7 @@ mod tests {
             shell,
             cfg: &DEFAULT_CFG,
             cwd: std::path::Path::new("/tmp"),
+            external_functions: Default::default(),
             external_aliases: Default::default(),
         }
     }
@@ -304,7 +295,7 @@ mod tests {
             &aliases,
             &SubcommandSet::new(),
         );
-        assert!(output.contains("_AM_ALIASES"));
+        assert!(output.contains(env_vars::AM_ALIASES));
     }
 
     #[test]
@@ -385,7 +376,7 @@ mod tests {
             &SubcommandSet::new(),
         );
         assert!(output.contains("__am_hook"));
-        assert!(!output.contains("_AM_ALIASES"));
+        assert!(!output.contains(env_vars::AM_ALIASES));
     }
 
     #[test]
@@ -402,7 +393,7 @@ mod tests {
         assert!(output.contains("functions -e old2"));
         assert!(output.contains("alias gs \"git status\""));
         assert!(output.contains("alias ll \"ls -lha\""));
-        assert!(output.contains("_AM_ALIASES"));
+        assert!(output.contains(env_vars::AM_ALIASES));
     }
 
     #[test]
@@ -616,7 +607,7 @@ mod tests {
             &AliasSet::default(),
             &subs,
         );
-        assert!(output.contains("_AM_ALIASES"));
+        assert!(output.contains(env_vars::AM_ALIASES));
         assert!(output.contains("jj"));
     }
     #[test]
@@ -630,6 +621,7 @@ mod tests {
             shell: &Shells::Fish,
             cfg: &cfg,
             cwd,
+            external_functions: Default::default(),
             external_aliases: Default::default(),
         };
         let mut aliases = AliasSet::default();
@@ -639,63 +631,6 @@ mod tests {
         );
         let output = generate_init(&ctx, &AliasSet::default(), &aliases, &SubcommandSet::new());
         assert!(output.contains("abbr --add gs \"git status\""));
-    }
-
-    #[test]
-    fn test_zsh_init_emits_preamble_for_colliding_external_alias() {
-        use std::collections::HashSet;
-        let aliases = test_aliases(); // contains "gs" and "ll"
-        let mut external = HashSet::new();
-        external.insert("gs".to_string()); // only "gs" collides
-
-        let ctx = ShellContext {
-            shell: &Shells::Zsh,
-            cfg: &DEFAULT_CFG,
-            cwd: std::path::Path::new("/tmp"),
-            external_aliases: external,
-        };
-        let output = generate_init(&ctx, &AliasSet::default(), &aliases, &SubcommandSet::new());
-
-        assert!(
-            output.contains("unalias gs 2>/dev/null; unset -f gs 2>/dev/null"),
-            "expected unalias preamble for gs, got:\n{output}"
-        );
-        let preamble_pos = output.find("unalias gs").unwrap();
-        let alias_pos = output.find("alias gs=").unwrap();
-        assert!(preamble_pos < alias_pos, "preamble must appear before alias definition");
-        assert!(!output.contains("unalias ll"), "should not emit preamble for ll");
-    }
-
-    #[test]
-    fn test_zsh_init_no_preamble_when_no_external_aliases() {
-        let aliases = test_aliases();
-        let output = generate_init(
-            &default_ctx(&Shells::Zsh),
-            &AliasSet::default(),
-            &aliases,
-            &SubcommandSet::new(),
-        );
-        assert!(!output.contains("unalias"), "no preamble expected when external_aliases is empty");
-    }
-
-    #[test]
-    fn test_zsh_init_preamble_only_for_managed_names() {
-        use std::collections::HashSet;
-        let mut external = HashSet::new();
-        external.insert("la".to_string());   // am does NOT manage "la"
-        external.insert("gs".to_string());   // am manages "gs"
-
-        let aliases = test_aliases(); // contains "gs" and "ll"
-        let ctx = ShellContext {
-            shell: &Shells::Zsh,
-            cfg: &DEFAULT_CFG,
-            cwd: std::path::Path::new("/tmp"),
-            external_aliases: external,
-        };
-        let output = generate_init(&ctx, &AliasSet::default(), &aliases, &SubcommandSet::new());
-
-        assert!(output.contains("unalias gs 2>/dev/null; unset -f gs 2>/dev/null"));
-        assert!(!output.contains("unalias la"), "must not touch unmanaged external alias");
     }
 
     #[test]
@@ -709,6 +644,7 @@ mod tests {
             shell: &Shells::Fish,
             cfg: &cfg,
             cwd,
+            external_functions: Default::default(),
             external_aliases: Default::default(),
         };
         let output = generate_reload(

--- a/crates/am/src/lib.rs
+++ b/crates/am/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod dirs;
 pub mod display;
 pub mod effects;
+pub mod env_vars;
 pub mod exchange;
 pub mod hook;
 pub mod import_export;

--- a/crates/am/src/shell/bash.rs
+++ b/crates/am/src/shell/bash.rs
@@ -1,8 +1,24 @@
-use super::{NixShell, Shell};
+use std::collections::HashSet;
+
+use super::{has_template_args, quote_cmd, substitute_nix, NixShell, Shell};
 use crate::alias::AliasEntry;
 
 #[derive(Debug, Default)]
-pub struct Bash;
+pub struct Bash {
+    /// Functions already defined in the user's shell — only emit `unset -f` for names here.
+    external_functions: HashSet<String>,
+    /// Aliases already defined in the user's shell — only emit `unalias` for names here.
+    external_aliases: HashSet<String>,
+}
+
+impl Bash {
+    pub fn new(external_functions: HashSet<String>, external_aliases: HashSet<String>) -> Self {
+        Bash {
+            external_functions,
+            external_aliases,
+        }
+    }
+}
 
 impl Shell for Bash {
     fn unalias(&self, alias_name: &str) -> String {
@@ -10,7 +26,28 @@ impl Shell for Bash {
     }
 
     fn alias(&self, entry: &AliasEntry) -> String {
-        NixShell.alias(entry)
+        if !entry.raw && has_template_args(entry.command) {
+            let body = substitute_nix(entry.command);
+            if self.external_aliases.contains(entry.name) {
+                format!(
+                    "unalias {} 2>/dev/null\n{}() {{ {}; }}",
+                    entry.name, entry.name, body
+                )
+            } else {
+                format!("{}() {{ {}; }}", entry.name, body)
+            }
+        } else {
+            if self.external_functions.contains(entry.name) {
+                format!(
+                    "unset -f {} 2>/dev/null\nalias {}={}",
+                    entry.name,
+                    entry.name,
+                    quote_cmd(entry.command)
+                )
+            } else {
+                format!("alias {}={}", entry.name, quote_cmd(entry.command))
+            }
+        }
     }
 
     fn set_env(&self, var_name: &str, value: &str) -> String {
@@ -32,5 +69,163 @@ impl Shell for Bash {
         entries: &[crate::subcommand::SubcommandEntry],
     ) -> String {
         NixShell.subcommand_wrapper(program, base_cmd, entries)
+    }
+}
+
+// ── Scanning helpers ──────────────────────────────────────────────────────────
+
+/// Parse the stdout of `declare -F` into a set of function names.
+///
+/// `declare -F` outputs one entry per line:
+///   declare -f am
+///   declare -f __git_ps1
+pub fn parse_bash_function_names(output: &str) -> HashSet<String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.split_whitespace();
+            // Must be exactly "declare -f <name>"
+            if parts.next() == Some("declare") && parts.next() == Some("-f") {
+                parts.next().map(|s| s.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Parse the stdout of `alias` into a set of alias names.
+///
+/// bash `alias` output prefixes each line with `alias `:
+///   alias gs='git status'
+///   alias ll='ls -lha'
+pub fn parse_bash_alias_names(output: &str) -> HashSet<String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let rest = line.trim().strip_prefix("alias ")?;
+            rest.split('=').next().map(|k| k.to_string())
+        })
+        .collect()
+}
+
+/// Scan function names defined in the user's interactive bash environment.
+pub fn scan_external_functions() -> HashSet<String> {
+    run_bash_inspect("declare -F", parse_bash_function_names)
+}
+
+/// Scan alias names defined in the user's interactive bash environment.
+pub fn scan_external_aliases() -> HashSet<String> {
+    run_bash_inspect("alias", parse_bash_alias_names)
+}
+
+fn run_bash_inspect(cmd: &str, parse: impl Fn(&str) -> HashSet<String>) -> HashSet<String> {
+    let output = std::process::Command::new("bash")
+        .args(["-i", "-c", cmd])
+        .env(crate::env_vars::AM_DETECTING_ALIASES, "1")
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() || out.status.code() == Some(1) => {
+            parse(&String::from_utf8_lossy(&out.stdout))
+        }
+        _ => HashSet::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shell::test_helpers::{raw, simple};
+
+    // ── native alias ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_bash_native_alias_no_cleanup_when_sets_empty() {
+        let bash = Bash::default();
+        assert_eq!(
+            bash.alias(&simple("gs", "git status")),
+            "alias gs=\"git status\""
+        );
+    }
+
+    #[test]
+    fn test_bash_native_alias_emits_unset_f_when_function_exists() {
+        let bash = Bash::new(HashSet::from(["gs".to_string()]), HashSet::new());
+        assert_eq!(
+            bash.alias(&simple("gs", "git status")),
+            "unset -f gs 2>/dev/null\nalias gs=\"git status\""
+        );
+        assert_eq!(bash.alias(&simple("ll", "ls -lha")), "alias ll=\"ls -lha\"");
+    }
+
+    // ── parameterised alias (function) ────────────────────────────────────
+
+    #[test]
+    fn test_bash_function_alias_no_cleanup_when_sets_empty() {
+        let bash = Bash::default();
+        assert_eq!(
+            bash.alias(&simple("cmf", "cm feat: {{@}}")),
+            "cmf() { cm feat: \"$@\"; }"
+        );
+    }
+
+    #[test]
+    fn test_bash_function_alias_emits_unalias_when_alias_exists() {
+        let bash = Bash::new(HashSet::new(), HashSet::from(["cmf".to_string()]));
+        assert_eq!(
+            bash.alias(&simple("cmf", "cm feat: {{@}}")),
+            "unalias cmf 2>/dev/null\ncmf() { cm feat: \"$@\"; }"
+        );
+        assert_eq!(
+            bash.alias(&simple("x", "echo {{1}}")),
+            "x() { echo \"$1\"; }"
+        );
+    }
+
+    #[test]
+    fn test_bash_raw_alias_skips_template_detection() {
+        let bash = Bash::new(HashSet::new(), HashSet::from(["my-awk".to_string()]));
+        assert_eq!(
+            bash.alias(&raw("my-awk", "awk '{print {{1}}}'")),
+            "alias my-awk=\"awk '{print {{1}}}'\""
+        );
+    }
+
+    // ── parsers ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_bash_function_names_handles_declare_f_output() {
+        let input = "declare -f am\ndeclare -f __git_ps1\ndeclare -f add-function\n";
+        let result = parse_bash_function_names(input);
+        assert_eq!(result.len(), 3);
+        assert!(result.contains("am"));
+        assert!(result.contains("__git_ps1"));
+        assert!(result.contains("add-function"));
+    }
+
+    #[test]
+    fn test_parse_bash_function_names_ignores_blank_and_unrelated_lines() {
+        let input = "\ndeclare -f am\n\nsome other line\ndeclare -f foo\n";
+        let result = parse_bash_function_names(input);
+        assert_eq!(result.len(), 2);
+        assert!(result.contains("am"));
+        assert!(result.contains("foo"));
+    }
+
+    #[test]
+    fn test_parse_bash_alias_names_handles_alias_prefix_format() {
+        let input = "alias gs='git status'\nalias ll='ls -lha'\nalias simple=value\n";
+        let result = parse_bash_alias_names(input);
+        assert_eq!(result.len(), 3);
+        assert!(result.contains("gs"));
+        assert!(result.contains("ll"));
+        assert!(result.contains("simple"));
+    }
+
+    #[test]
+    fn test_parse_bash_alias_names_ignores_blank_lines() {
+        let result = parse_bash_alias_names("\nalias gs='git status'\n\nalias ll='ls -lha'\n");
+        assert_eq!(result.len(), 2);
     }
 }

--- a/crates/am/src/shell/mod.rs
+++ b/crates/am/src/shell/mod.rs
@@ -1,4 +1,4 @@
-mod bash;
+pub(crate) mod bash;
 mod brush;
 mod fish;
 mod nix;
@@ -7,13 +7,11 @@ mod powershell;
 mod shell;
 pub(crate) mod zsh;
 
-pub use bash::*;
 pub use brush::*;
 pub use fish::*;
 pub use nix::*;
 pub use powershell::*;
 pub use shell::*;
-pub use zsh::*;
 
 #[cfg(test)]
 pub(crate) mod test_helpers {

--- a/crates/am/src/shell/mod.rs
+++ b/crates/am/src/shell/mod.rs
@@ -5,7 +5,7 @@ mod nix;
 mod powershell;
 #[allow(clippy::module_inception)]
 mod shell;
-mod zsh;
+pub mod zsh;
 
 pub use bash::*;
 pub use brush::*;

--- a/crates/am/src/shell/mod.rs
+++ b/crates/am/src/shell/mod.rs
@@ -5,7 +5,7 @@ mod nix;
 mod powershell;
 #[allow(clippy::module_inception)]
 mod shell;
-pub mod zsh;
+pub(crate) mod zsh;
 
 pub use bash::*;
 pub use brush::*;

--- a/crates/am/src/shell/nix.rs
+++ b/crates/am/src/shell/nix.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 
-use super::{build_wrapper_trie, has_template_args, substitute_nix, Shell, WrapperNode};
+use super::{build_wrapper_trie, has_template_args, quote_cmd, substitute_nix, Shell, WrapperNode};
 use crate::alias::AliasEntry;
 use crate::subcommand::SubcommandEntry;
 
@@ -10,7 +10,7 @@ pub struct NixShell;
 
 impl Shell for NixShell {
     fn unalias(&self, alias_name: &str) -> String {
-        format!("unset -f {alias_name}")
+        format!("unalias {alias_name} 2>/dev/null; unset -f {alias_name} 2>/dev/null")
     }
 
     fn alias(&self, entry: &AliasEntry) -> String {
@@ -18,7 +18,7 @@ impl Shell for NixShell {
             let body = substitute_nix(entry.command);
             format!("{}() {{ {}; }}", entry.name, body)
         } else {
-            format!("{}() {{ {} \"$@\"; }}", entry.name, entry.command)
+            format!("alias {}={}", entry.name, quote_cmd(entry.command))
         }
     }
 
@@ -127,7 +127,11 @@ mod tests {
     fn test_nix_simple() {
         assert_eq!(
             NixShell.alias(&simple("h", "echo hello")),
-            "h() { echo hello \"$@\"; }"
+            "alias h=\"echo hello\""
+        );
+        assert_eq!(
+            NixShell.alias(&simple("h", "'echo hello'")),
+            "alias h='echo hello'"
         );
     }
 
@@ -147,13 +151,16 @@ mod tests {
     fn test_nix_raw_skips_templates() {
         assert_eq!(
             NixShell.alias(&raw("my-awk", "awk '{print {{1}}}'")),
-            "my-awk() { awk '{print {{1}}}' \"$@\"; }"
+            "alias my-awk=\"awk '{print {{1}}}'\""
         );
     }
 
     #[test]
     fn test_nix_unalias() {
-        assert_eq!(NixShell.unalias("h"), "unset -f h");
+        assert_eq!(
+            NixShell.unalias("h"),
+            "unalias h 2>/dev/null; unset -f h 2>/dev/null"
+        );
     }
 
     #[test]

--- a/crates/am/src/shell/nix.rs
+++ b/crates/am/src/shell/nix.rs
@@ -18,7 +18,13 @@ impl Shell for NixShell {
             let body = substitute_nix(entry.command);
             format!("{}() {{ {}; }}", entry.name, body)
         } else {
-            format!("alias {}={}", entry.name, quote_cmd(entry.command))
+            // Emitting a native alias — clear any existing function that would shadow it.
+            format!(
+                "unset -f {} 2>/dev/null\nalias {}={}",
+                entry.name,
+                entry.name,
+                quote_cmd(entry.command)
+            )
         }
     }
 
@@ -41,6 +47,11 @@ impl Shell for NixShell {
         entries: &[SubcommandEntry],
     ) -> String {
         let mut lines = Vec::new();
+        // If the program also has a plain alias entry (base_cmd is the alias expansion, not
+        // "command <program>"), clear it so the wrapper function is not shadowed.
+        if base_cmd != format!("command {program}") {
+            lines.push(format!("unalias {program} 2>/dev/null"));
+        }
         lines.push(format!("{program}() {{"));
         let roots = build_wrapper_trie(entries);
         emit_nix_switch(&mut lines, &roots, 1, base_cmd, "  ", None);
@@ -127,11 +138,11 @@ mod tests {
     fn test_nix_simple() {
         assert_eq!(
             NixShell.alias(&simple("h", "echo hello")),
-            "alias h=\"echo hello\""
+            "unset -f h 2>/dev/null\nalias h=\"echo hello\""
         );
         assert_eq!(
             NixShell.alias(&simple("h", "'echo hello'")),
-            "alias h='echo hello'"
+            "unset -f h 2>/dev/null\nalias h='echo hello'"
         );
     }
 
@@ -151,7 +162,7 @@ mod tests {
     fn test_nix_raw_skips_templates() {
         assert_eq!(
             NixShell.alias(&raw("my-awk", "awk '{print {{1}}}'")),
-            "alias my-awk=\"awk '{print {{1}}}'\""
+            "unset -f my-awk 2>/dev/null\nalias my-awk=\"awk '{print {{1}}}'\""
         );
     }
 
@@ -177,6 +188,8 @@ mod tests {
             long_subcommands: vec!["abandon".into()],
         }];
         let output = NixShell.subcommand_wrapper("jj", "command jj", &entries);
+        // No alias entry for jj → no unalias guard needed
+        assert!(!output.contains("unalias jj"));
         assert!(output.contains("jj() {"));
         assert!(output.contains("ab) shift; command jj abandon \"$@\" ;;"));
         assert!(output.contains("*) command jj \"$@\" ;;"));
@@ -190,6 +203,9 @@ mod tests {
             long_subcommands: vec!["abandon".into()],
         }];
         let output = NixShell.subcommand_wrapper("jj", "just-a-joke", &entries);
+        // jj has an alias entry (just-a-joke) → clear any existing alias before the function
+        assert!(output.contains("unalias jj 2>/dev/null"));
+        assert!(output.find("unalias jj").unwrap() < output.find("jj() {").unwrap());
         assert!(output.contains("ab) shift; just-a-joke abandon \"$@\" ;;"));
         assert!(output.contains("*) just-a-joke \"$@\" ;;"));
     }

--- a/crates/am/src/shell/shell.rs
+++ b/crates/am/src/shell/shell.rs
@@ -44,18 +44,23 @@ pub struct ShellContext<'a> {
     pub shell: &'a Shells,
     pub cfg: &'a ShellsTomlConfig,
     pub cwd: &'a std::path::Path,
-    /// External aliases detected from the user's shell startup files.
-    /// Used by `generate_init` to emit a cleanup preamble for colliding names.
-    /// Empty for all shells except zsh on `am init`.
+    /// Functions already defined in the user's shell — zsh only emits `unset -f` for names here.
+    pub external_functions: std::collections::HashSet<String>,
+    /// Aliases already defined in the user's shell — zsh only emits `unalias` for names here.
     pub external_aliases: std::collections::HashSet<String>,
 }
 
 impl Shells {
-    pub fn as_shell(self, shell_cfg: &ShellsTomlConfig) -> Box<dyn Shell> {
+    pub fn as_shell(
+        self,
+        shell_cfg: &ShellsTomlConfig,
+        external_functions: std::collections::HashSet<String>,
+        external_aliases: std::collections::HashSet<String>,
+    ) -> Box<dyn Shell> {
         match self {
             Shells::Fish => Box::new(super::fish::Fish::from_config(shell_cfg.fish.as_ref())),
-            Shells::Zsh => Box::from(super::zsh::Zsh),
-            Shells::Bash => Box::from(super::bash::Bash),
+            Shells::Zsh => Box::new(super::zsh::Zsh::new(external_functions, external_aliases)),
+            Shells::Bash => Box::new(super::bash::Bash::new(external_functions, external_aliases)),
             Shells::Brush => Box::from(super::brush::Brush),
             Shells::Powershell => Box::from(super::powershell::PowerShell),
         }
@@ -305,7 +310,11 @@ mod tests {
 
     #[test]
     fn test_bash_shell_generates_nix_syntax() {
-        let shell: Box<dyn Shell> = Shells::Bash.as_shell(&ShellsTomlConfig::default());
+        let shell: Box<dyn Shell> = Shells::Bash.as_shell(
+            &ShellsTomlConfig::default(),
+            Default::default(),
+            Default::default(),
+        );
         let entry = simple("gs", "git status");
         assert_eq!(shell.alias(&entry), "alias gs=\"git status\"");
         assert_eq!(

--- a/crates/am/src/shell/shell.rs
+++ b/crates/am/src/shell/shell.rs
@@ -303,8 +303,11 @@ mod tests {
     fn test_bash_shell_generates_nix_syntax() {
         let shell: Box<dyn Shell> = Shells::Bash.as_shell(&ShellsTomlConfig::default());
         let entry = simple("gs", "git status");
-        assert_eq!(shell.alias(&entry), "gs() { git status \"$@\"; }");
-        assert_eq!(shell.unalias("gs"), "unset -f gs");
+        assert_eq!(shell.alias(&entry), "alias gs=\"git status\"");
+        assert_eq!(
+            shell.unalias("gs"),
+            "unalias gs 2>/dev/null; unset -f gs 2>/dev/null"
+        );
         assert_eq!(shell.set_env("FOO", "bar"), "export FOO=\"bar\"");
         assert_eq!(shell.unset_env("FOO"), "unset FOO");
     }

--- a/crates/am/src/shell/shell.rs
+++ b/crates/am/src/shell/shell.rs
@@ -44,6 +44,10 @@ pub struct ShellContext<'a> {
     pub shell: &'a Shells,
     pub cfg: &'a ShellsTomlConfig,
     pub cwd: &'a std::path::Path,
+    /// External aliases detected from the user's shell startup files.
+    /// Used by `generate_init` to emit a cleanup preamble for colliding names.
+    /// Empty for all shells except zsh on `am init`.
+    pub external_aliases: std::collections::HashSet<String>,
 }
 
 impl Shells {

--- a/crates/am/src/shell/zsh.rs
+++ b/crates/am/src/shell/zsh.rs
@@ -1,8 +1,26 @@
-use super::{NixShell, Shell};
+use std::collections::HashSet;
+
+use super::{has_template_args, quote_cmd, NixShell, Shell};
 use crate::alias::AliasEntry;
 
 #[derive(Debug, Default)]
-pub struct Zsh;
+pub struct Zsh {
+    /// Functions already defined in the user's shell — used to conditionally emit
+    /// `unset -f <name>` before a native alias that would otherwise be shadowed.
+    external_functions: HashSet<String>,
+    /// Aliases already defined in the user's shell — used to conditionally emit
+    /// `unalias <name>` before a function that would otherwise be shadowed.
+    external_aliases: HashSet<String>,
+}
+
+impl Zsh {
+    pub fn new(external_functions: HashSet<String>, external_aliases: HashSet<String>) -> Self {
+        Zsh {
+            external_functions,
+            external_aliases,
+        }
+    }
+}
 
 impl Shell for Zsh {
     fn unalias(&self, alias_name: &str) -> String {
@@ -10,7 +28,30 @@ impl Shell for Zsh {
     }
 
     fn alias(&self, entry: &AliasEntry) -> String {
-        NixShell.alias(entry)
+        if !entry.raw && has_template_args(entry.command) {
+            // Parameterised → function; only clear a conflicting alias when we know it exists.
+            let body = super::substitute_nix(entry.command);
+            if self.external_aliases.contains(entry.name) {
+                format!(
+                    "unalias {} 2>/dev/null\n{}() {{ {}; }}",
+                    entry.name, entry.name, body
+                )
+            } else {
+                format!("{}() {{ {}; }}", entry.name, body)
+            }
+        } else {
+            // Native alias: only clear a conflicting function when we know it exists.
+            if self.external_functions.contains(entry.name) {
+                format!(
+                    "unset -f {} 2>/dev/null\nalias {}={}",
+                    entry.name,
+                    entry.name,
+                    quote_cmd(entry.command)
+                )
+            } else {
+                format!("alias {}={}", entry.name, quote_cmd(entry.command))
+            }
+        }
     }
 
     fn set_env(&self, var_name: &str, value: &str) -> String {
@@ -35,11 +76,37 @@ impl Shell for Zsh {
     }
 }
 
-/// Parses the raw stdout of `zsh -i -c 'alias'` into a set of alias names.
+// ── Scanning helpers ──────────────────────────────────────────────────────────
+
+/// Parse the stdout of `typeset +f` into a set of function names.
 ///
-/// Each line follows the grammar: `name=value` or `name='quoted value'`.
+/// `typeset +f` outputs one bare function name per line, e.g.:
+///   add-zsh-hook
+///   compinit
+///   am
+pub fn parse_zsh_function_names(output: &str) -> HashSet<String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let name = line.trim();
+            if name.is_empty() {
+                None
+            } else {
+                Some(name.to_string())
+            }
+        })
+        .collect()
+}
+
+/// Parse the stdout of `alias` into a set of alias names.
+///
+/// zsh `alias` output lines follow the grammar:
+///   name=value
+///   name='quoted value'
+///   name='it'\''s here'   (embedded single-quote)
+///
 /// Only the key (left of the first `=`) is extracted.
-pub(crate) fn parse_zsh_alias_keys(output: &str) -> std::collections::HashSet<String> {
+pub fn parse_zsh_alias_names(output: &str) -> HashSet<String> {
     output
         .lines()
         .filter_map(|line| {
@@ -52,63 +119,128 @@ pub(crate) fn parse_zsh_alias_keys(output: &str) -> std::collections::HashSet<St
         .collect()
 }
 
-/// Spawns `zsh -i -c 'alias'` and returns the set of alias names defined in
-/// the user's zsh startup files.
-///
-/// Returns an empty set on any error — scan failure is non-fatal.
-/// Sets `AM_DETECTING_ALIASES=1` to prevent recursive `am` invocation if
-/// `.zshrc` contains `eval "$(am init zsh)"`.
-pub fn scan_external_aliases() -> std::collections::HashSet<String> {
-    // Guard against recursive invocation: if we are already inside a
-    // `zsh -i -c alias` subprocess triggered by an outer scan, return empty
-    // immediately rather than spawning another child.
-    if std::env::var("AM_DETECTING_ALIASES").is_ok() {
-        return Default::default();
-    }
+/// Scan function names defined in the user's interactive zsh environment.
+pub fn scan_external_functions() -> HashSet<String> {
+    run_zsh_inspect("typeset +f", parse_zsh_function_names)
+}
+
+/// Scan alias names defined in the user's interactive zsh environment.
+pub fn scan_external_aliases() -> HashSet<String> {
+    run_zsh_inspect("alias", parse_zsh_alias_names)
+}
+
+fn run_zsh_inspect(cmd: &str, parse: impl Fn(&str) -> HashSet<String>) -> HashSet<String> {
     let output = std::process::Command::new("zsh")
-        .args(["-i", "-c", "alias"])
-        .env("AM_DETECTING_ALIASES", "1")
-        .stderr(std::process::Stdio::null())
+        .args(["-i", "-c", cmd])
+        .env(crate::env_vars::AM_DETECTING_ALIASES, "1")
         .output();
+
     match output {
-        Ok(out) => parse_zsh_alias_keys(&String::from_utf8_lossy(&out.stdout)),
-        Err(_) => Default::default(),
+        Ok(out) if out.status.success() || out.status.code() == Some(1) => {
+            parse(&String::from_utf8_lossy(&out.stdout))
+        }
+        _ => HashSet::new(),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::shell::test_helpers::{raw, simple};
+
+    // ── native alias (no template args) ──────────────────────────────────
 
     #[test]
-    fn parse_alias_keys_handles_quoted_values() {
-        let raw = "gs='git status'\nll='ls -lh'\n";
-        let keys = parse_zsh_alias_keys(raw);
-        assert!(keys.contains("gs"));
-        assert!(keys.contains("ll"));
-        assert_eq!(keys.len(), 2);
+    fn test_zsh_native_alias_no_cleanup_when_sets_empty() {
+        let zsh = Zsh::default();
+        assert_eq!(
+            zsh.alias(&simple("gs", "git status")),
+            "alias gs=\"git status\""
+        );
     }
 
     #[test]
-    fn parse_alias_keys_handles_all_formats() {
-        let raw = "gs='git status'\nll='ls -lh'\ncomplex='it'\\''s a value'\nsimple=value\n";
-        let keys = parse_zsh_alias_keys(raw);
-        assert!(keys.contains("gs"));
-        assert!(keys.contains("ll"));
-        assert!(keys.contains("complex"));
-        assert!(keys.contains("simple"));
-        assert_eq!(keys.len(), 4);
+    fn test_zsh_native_alias_emits_unset_f_when_function_exists() {
+        let fns = HashSet::from(["gs".to_string()]);
+        let zsh = Zsh::new(fns, HashSet::new());
+
+        assert_eq!(
+            zsh.alias(&simple("gs", "git status")),
+            "unset -f gs 2>/dev/null\nalias gs=\"git status\""
+        );
+        // ll not in set → no cleanup
+        assert_eq!(zsh.alias(&simple("ll", "ls -lha")), "alias ll=\"ls -lha\"");
+    }
+
+    // ── parameterised alias (template args → function) ────────────────────
+
+    #[test]
+    fn test_zsh_function_alias_no_cleanup_when_sets_empty() {
+        let zsh = Zsh::default();
+        assert_eq!(
+            zsh.alias(&simple("cmf", "cm feat: {{@}}")),
+            "cmf() { cm feat: \"$@\"; }"
+        );
     }
 
     #[test]
-    fn parse_alias_keys_empty_input_returns_empty_set() {
-        assert!(parse_zsh_alias_keys("").is_empty());
+    fn test_zsh_function_alias_emits_unalias_when_alias_exists() {
+        let aliases = HashSet::from(["cmf".to_string()]);
+        let zsh = Zsh::new(HashSet::new(), aliases);
+
+        assert_eq!(
+            zsh.alias(&simple("cmf", "cm feat: {{@}}")),
+            "unalias cmf 2>/dev/null\ncmf() { cm feat: \"$@\"; }"
+        );
+        // x not in aliases set → no unalias
+        assert_eq!(
+            zsh.alias(&simple("x", "echo {{1}}")),
+            "x() { echo \"$1\"; }"
+        );
     }
 
     #[test]
-    fn parse_alias_keys_ignores_blank_lines() {
-        let raw = "\ngs='git status'\n\nll='ls -lh'\n\n";
-        let keys = parse_zsh_alias_keys(raw);
-        assert_eq!(keys.len(), 2);
+    fn test_zsh_raw_alias_never_emits_unalias() {
+        // raw = true skips template detection → always native alias path
+        let aliases = HashSet::from(["my-awk".to_string()]);
+        let zsh = Zsh::new(HashSet::new(), aliases);
+        assert_eq!(
+            zsh.alias(&raw("my-awk", "awk '{print {{1}}}'")),
+            "alias my-awk=\"awk '{print {{1}}}'\""
+        );
+    }
+
+    // ── parsers ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_zsh_function_names_handles_typical_output() {
+        let raw = "add-zsh-hook\ncompinit\nam\namoxide_hook\n";
+        let result = parse_zsh_function_names(raw);
+        assert_eq!(result.len(), 4);
+        assert!(result.contains("add-zsh-hook"));
+        assert!(result.contains("am"));
+    }
+
+    #[test]
+    fn test_parse_zsh_function_names_ignores_blank_lines() {
+        let result = parse_zsh_function_names("\nadd-zsh-hook\n\ncompinit\n\n");
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_zsh_alias_names_handles_various_formats() {
+        let input = "gs='git status'\nll='ls -lh'\ncomplex='it'\\''s a value'\nsimple=value\n";
+        let result = parse_zsh_alias_names(input);
+        assert_eq!(result.len(), 4);
+        assert!(result.contains("gs"));
+        assert!(result.contains("ll"));
+        assert!(result.contains("complex"));
+        assert!(result.contains("simple"));
+    }
+
+    #[test]
+    fn test_parse_zsh_alias_names_ignores_blank_lines() {
+        let result = parse_zsh_alias_names("\ngs='git status'\n\nll='ls -lh'\n");
+        assert_eq!(result.len(), 2);
     }
 }

--- a/crates/am/src/shell/zsh.rs
+++ b/crates/am/src/shell/zsh.rs
@@ -47,7 +47,7 @@ pub(crate) fn parse_zsh_alias_keys(output: &str) -> std::collections::HashSet<St
             if line.is_empty() {
                 return None;
             }
-            line.splitn(2, '=').next().map(|k| k.to_string())
+            line.split('=').next().map(|k| k.to_string())
         })
         .collect()
 }
@@ -59,6 +59,12 @@ pub(crate) fn parse_zsh_alias_keys(output: &str) -> std::collections::HashSet<St
 /// Sets `AM_DETECTING_ALIASES=1` to prevent recursive `am` invocation if
 /// `.zshrc` contains `eval "$(am init zsh)"`.
 pub fn scan_external_aliases() -> std::collections::HashSet<String> {
+    // Guard against recursive invocation: if we are already inside a
+    // `zsh -i -c alias` subprocess triggered by an outer scan, return empty
+    // immediately rather than spawning another child.
+    if std::env::var("AM_DETECTING_ALIASES").is_ok() {
+        return Default::default();
+    }
     let output = std::process::Command::new("zsh")
         .args(["-i", "-c", "alias"])
         .env("AM_DETECTING_ALIASES", "1")

--- a/crates/am/src/shell/zsh.rs
+++ b/crates/am/src/shell/zsh.rs
@@ -62,6 +62,7 @@ pub fn scan_external_aliases() -> std::collections::HashSet<String> {
     let output = std::process::Command::new("zsh")
         .args(["-i", "-c", "alias"])
         .env("AM_DETECTING_ALIASES", "1")
+        .stderr(std::process::Stdio::null())
         .output();
     match output {
         Ok(out) => parse_zsh_alias_keys(&String::from_utf8_lossy(&out.stdout)),

--- a/crates/am/src/shell/zsh.rs
+++ b/crates/am/src/shell/zsh.rs
@@ -34,3 +34,74 @@ impl Shell for Zsh {
         NixShell.subcommand_wrapper(program, base_cmd, entries)
     }
 }
+
+/// Parses the raw stdout of `zsh -i -c 'alias'` into a set of alias names.
+///
+/// Each line follows the grammar: `name=value` or `name='quoted value'`.
+/// Only the key (left of the first `=`) is extracted.
+pub(crate) fn parse_zsh_alias_keys(output: &str) -> std::collections::HashSet<String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() {
+                return None;
+            }
+            line.splitn(2, '=').next().map(|k| k.to_string())
+        })
+        .collect()
+}
+
+/// Spawns `zsh -i -c 'alias'` and returns the set of alias names defined in
+/// the user's zsh startup files.
+///
+/// Returns an empty set on any error — scan failure is non-fatal.
+/// Sets `AM_DETECTING_ALIASES=1` to prevent recursive `am` invocation if
+/// `.zshrc` contains `eval "$(am init zsh)"`.
+pub fn scan_external_aliases() -> std::collections::HashSet<String> {
+    let output = std::process::Command::new("zsh")
+        .args(["-i", "-c", "alias"])
+        .env("AM_DETECTING_ALIASES", "1")
+        .output();
+    match output {
+        Ok(out) => parse_zsh_alias_keys(&String::from_utf8_lossy(&out.stdout)),
+        Err(_) => Default::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_alias_keys_handles_quoted_values() {
+        let raw = "gs='git status'\nll='ls -lh'\n";
+        let keys = parse_zsh_alias_keys(raw);
+        assert!(keys.contains("gs"));
+        assert!(keys.contains("ll"));
+        assert_eq!(keys.len(), 2);
+    }
+
+    #[test]
+    fn parse_alias_keys_handles_all_formats() {
+        let raw = "gs='git status'\nll='ls -lh'\ncomplex='it'\\''s a value'\nsimple=value\n";
+        let keys = parse_zsh_alias_keys(raw);
+        assert!(keys.contains("gs"));
+        assert!(keys.contains("ll"));
+        assert!(keys.contains("complex"));
+        assert!(keys.contains("simple"));
+        assert_eq!(keys.len(), 4);
+    }
+
+    #[test]
+    fn parse_alias_keys_empty_input_returns_empty_set() {
+        assert!(parse_zsh_alias_keys("").is_empty());
+    }
+
+    #[test]
+    fn parse_alias_keys_ignores_blank_lines() {
+        let raw = "\ngs='git status'\n\nll='ls -lh'\n\n";
+        let keys = parse_zsh_alias_keys(raw);
+        assert_eq!(keys.len(), 2);
+    }
+}

--- a/crates/am/src/update.rs
+++ b/crates/am/src/update.rs
@@ -2,9 +2,11 @@ pub use crate::app_model::AppModel;
 
 use crate::display::render_listing;
 use crate::effects::Effect;
+use crate::env_vars;
 use crate::init::{generate_init, generate_reload};
 use crate::profile::AliasCollection;
 use crate::project::ProjectAliases;
+use crate::shell::bash;
 use crate::shell::zsh;
 use crate::shell::ShellContext;
 use crate::shell::Shells;
@@ -565,15 +567,19 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
             for (k, v) in resolved_subs {
                 all_subs.insert(k, v);
             }
-            let external_aliases = if shell == Shells::Zsh {
-                zsh::scan_external_aliases()
-            } else {
-                Default::default()
+            let (external_functions, external_aliases) = match shell {
+                Shells::Zsh => (zsh::scan_external_functions(), zsh::scan_external_aliases()),
+                Shells::Bash => (
+                    bash::scan_external_functions(),
+                    bash::scan_external_aliases(),
+                ),
+                _ => Default::default(),
             };
             let ctx = ShellContext {
                 shell: &shell,
                 cfg: &model.config.shell,
                 cwd: &model.cwd,
+                external_functions,
                 external_aliases,
             };
             let output = generate_init(&ctx, &model.config.aliases, &resolved, &all_subs);
@@ -591,11 +597,12 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
             for (k, v) in resolved_subs {
                 all_subs.insert(k, v);
             }
-            let prev = std::env::var("_AM_ALIASES").ok();
+            let prev = std::env::var(env_vars::AM_ALIASES).ok();
             let ctx = ShellContext {
                 shell: &shell,
                 cfg: &model.config.shell,
                 cwd: &model.cwd,
+                external_functions: Default::default(),
                 external_aliases: Default::default(),
             };
             let output = generate_reload(
@@ -611,14 +618,15 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
             Ok(UpdateResult::done())
         }
         Message::Hook(shell, quiet) => {
-            let prev = std::env::var("_AM_PROJECT_ALIASES").ok();
-            let prev_project_path = std::env::var("_AM_PROJECT_PATH").ok();
+            let prev = std::env::var(env_vars::AM_PROJECT_ALIASES).ok();
+            let prev_project_path = std::env::var(env_vars::AM_PROJECT_PATH).ok();
             let shell_cfg = model.config.shell.clone();
             let cwd = model.cwd.clone();
             let ctx = ShellContext {
                 shell: &shell,
                 cfg: &shell_cfg,
                 cwd: &cwd,
+                external_functions: Default::default(),
                 external_aliases: Default::default(),
             };
             let (output, security_changed) = crate::hook::generate_hook_with_security(

--- a/crates/am/src/update.rs
+++ b/crates/am/src/update.rs
@@ -567,6 +567,7 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                 shell: &shell,
                 cfg: &model.config.shell,
                 cwd: &model.cwd,
+                external_aliases: Default::default(),
             };
             let output = generate_init(&ctx, &model.config.aliases, &resolved, &all_subs);
             print!("{output}");
@@ -588,6 +589,7 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                 shell: &shell,
                 cfg: &model.config.shell,
                 cwd: &model.cwd,
+                external_aliases: Default::default(),
             };
             let output = generate_reload(
                 &ctx,
@@ -610,6 +612,7 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                 shell: &shell,
                 cfg: &shell_cfg,
                 cwd: &cwd,
+                external_aliases: Default::default(),
             };
             let (output, security_changed) = crate::hook::generate_hook_with_security(
                 &ctx,

--- a/crates/am/src/update.rs
+++ b/crates/am/src/update.rs
@@ -5,7 +5,9 @@ use crate::effects::Effect;
 use crate::init::{generate_init, generate_reload};
 use crate::profile::AliasCollection;
 use crate::project::ProjectAliases;
+use crate::shell::zsh;
 use crate::shell::ShellContext;
+use crate::shell::Shells;
 use crate::trust::ProjectTrust;
 use crate::{profile, AliasDisplayFilter, AliasTarget, Message, Profile};
 
@@ -563,11 +565,16 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
             for (k, v) in resolved_subs {
                 all_subs.insert(k, v);
             }
+            let external_aliases = if shell == Shells::Zsh {
+                zsh::scan_external_aliases()
+            } else {
+                Default::default()
+            };
             let ctx = ShellContext {
                 shell: &shell,
                 cfg: &model.config.shell,
                 cwd: &model.cwd,
-                external_aliases: Default::default(),
+                external_aliases,
             };
             let output = generate_init(&ctx, &model.config.aliases, &resolved, &all_subs);
             print!("{output}");

--- a/crates/am/tests/e2e.rs
+++ b/crates/am/tests/e2e.rs
@@ -1,0 +1,103 @@
+/// End-to-end tests that require a real shell environment on the host machine.
+///
+/// All tests here are marked `#[ignore]` so they are skipped by the default
+/// `cargo test` run.  Run them explicitly with:
+///
+///   cargo test --test e2e -- --ignored
+///
+/// CI primes the shell environment before invoking this suite.
+use std::process::Command;
+
+/// Proof that the `_AM_DETECTING_ALIASES` guard works: when `am hook` is invoked
+/// while the env var is set (as it happens during alias scanning), the binary must
+/// exit cleanly with no stdout so that `eval "$(...)"` in shell startup scripts
+/// is a no-op — preventing infinite recursion.
+///
+/// Without the guard `am hook zsh` in a directory containing an `.aliases` file
+/// outputs shell code (at minimum a trust warning), which would be eval'd by the
+/// child zsh and could trigger another scan cycle.
+#[test]
+#[ignore = "e2e: requires the am binary and a zsh installation"]
+fn am_hook_is_silent_when_am_detecting_aliases_guard_is_active() {
+    let dir = tempfile::tempdir().expect("failed to create temp dir");
+    std::fs::write(
+        dir.path().join(".aliases"),
+        "[aliases]\nb = \"make build\"\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_am"))
+        .args(["hook", "zsh"])
+        .env("_AM_DETECTING_ALIASES", "1")
+        .env_remove("_AM_PROJECT_ALIASES")
+        .env_remove("_AM_PROJECT_PATH")
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn am binary");
+
+    assert!(
+        output.status.success(),
+        "am should exit 0 when the guard is active, got: {}",
+        output.status
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.is_empty(),
+        "am hook must produce no stdout when _AM_DETECTING_ALIASES is set\n\
+         (any output would be eval'd by the shell and could cause recursion)\n\
+         got: {stdout:?}"
+    );
+}
+
+/// Proof that `zsh -i -c 'alias'` enumerates pre-existing aliases from the
+/// user's shell config.
+///
+/// CI primes `~/.zshrc` with `alias la='ls -lAh'` before running this suite.
+/// On a local machine the alias must be present in `~/.zshrc` (or a sourced
+/// plugin) for this test to pass.
+#[test]
+#[ignore = "e2e: requires zsh and la='ls -lAh' defined in ~/.zshrc"]
+fn zsh_interactive_alias_output_contains_la() {
+    let output = Command::new("zsh")
+        .args(["-i", "-c", "alias"])
+        .env("_AM_DETECTING_ALIASES", "1")
+        .output()
+        .expect("failed to spawn zsh — is zsh installed?");
+
+    assert!(
+        output.status.success() || output.status.code() == Some(1),
+        "zsh exited with unexpected status: {}",
+        output.status
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.is_empty(),
+        "zsh produced no alias output — is ~/.zshrc sourced correctly?"
+    );
+
+    let keys: Vec<String> = stdout
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() {
+                return None;
+            }
+            line.split('=').next().map(|k| k.to_string())
+        })
+        .collect();
+
+    assert!(
+        keys.len() > 5,
+        "expected many aliases from interactive zsh, got only {}: \
+         check that zsh sources ~/.zshrc in interactive mode",
+        keys.len()
+    );
+
+    assert!(
+        keys.contains(&"la".to_string()),
+        "`la` alias not found among {} aliases: {:?}",
+        keys.len(),
+        keys
+    );
+}

--- a/crates/am/tests/e2e.rs
+++ b/crates/am/tests/e2e.rs
@@ -87,13 +87,9 @@ fn zsh_interactive_alias_output_contains_la() {
         })
         .collect();
 
-    assert!(
-        keys.len() > 5,
-        "expected many aliases from interactive zsh, got only {}: \
-         check that zsh sources ~/.zshrc in interactive mode",
-        keys.len()
-    );
-
+    // The concrete proof: `la` must be present — CI seeds it via
+    // `echo "alias la='ls -lAh'" >> ~/.zshrc`, on dev machines it comes from
+    // the user's shell config or plugins.
     assert!(
         keys.contains(&"la".to_string()),
         "`la` alias not found among {} aliases: {:?}",

--- a/crates/am/tests/snapshots.rs
+++ b/crates/am/tests/snapshots.rs
@@ -21,6 +21,7 @@ fn default_ctx(shell: &Shells) -> ShellContext<'_> {
         shell,
         cfg: &DEFAULT_CFG,
         cwd: std::path::Path::new("/tmp"),
+        external_functions: Default::default(),
         external_aliases: Default::default(),
     }
 }
@@ -489,6 +490,7 @@ fn snapshot_hook_fish_with_aliases() {
         shell: &Shells::Fish,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
+        external_functions: Default::default(),
         external_aliases: Default::default(),
     };
     let (output, _) = generate_hook_with_security(&ctx, None, None, &mut security, false).unwrap();
@@ -517,6 +519,7 @@ fn snapshot_hook_zsh_with_aliases() {
         shell: &Shells::Zsh,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
+        external_functions: Default::default(),
         external_aliases: Default::default(),
     };
     let (output, _) = generate_hook_with_security(&ctx, None, None, &mut security, false).unwrap();
@@ -545,6 +548,7 @@ fn snapshot_hook_powershell_with_aliases() {
         shell: &Shells::Powershell,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
+        external_functions: Default::default(),
         external_aliases: Default::default(),
     };
     let (output, _) = generate_hook_with_security(&ctx, None, None, &mut security, false).unwrap();
@@ -573,6 +577,7 @@ fn snapshot_hook_bash_with_aliases() {
         shell: &Shells::Bash,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
+        external_functions: Default::default(),
         external_aliases: Default::default(),
     };
     let (output, _) = generate_hook_with_security(&ctx, None, None, &mut security, false).unwrap();
@@ -600,6 +605,7 @@ fn snapshot_hook_fish_transition() {
         shell: &Shells::Fish,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
+        external_functions: Default::default(),
         external_aliases: Default::default(),
     };
     let (output, _) =
@@ -616,6 +622,7 @@ fn snapshot_hook_fish_leaving_project() {
         shell: &Shells::Fish,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
+        external_functions: Default::default(),
         external_aliases: Default::default(),
     };
     let (output, _) =

--- a/crates/am/tests/snapshots.rs
+++ b/crates/am/tests/snapshots.rs
@@ -21,6 +21,7 @@ fn default_ctx(shell: &Shells) -> ShellContext<'_> {
         shell,
         cfg: &DEFAULT_CFG,
         cwd: std::path::Path::new("/tmp"),
+        external_aliases: Default::default(),
     }
 }
 use indoc::indoc;
@@ -488,6 +489,7 @@ fn snapshot_hook_fish_with_aliases() {
         shell: &Shells::Fish,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
+        external_aliases: Default::default(),
     };
     let (output, _) = generate_hook_with_security(&ctx, None, None, &mut security, false).unwrap();
     insta::assert_snapshot!(output);
@@ -515,6 +517,7 @@ fn snapshot_hook_zsh_with_aliases() {
         shell: &Shells::Zsh,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
+        external_aliases: Default::default(),
     };
     let (output, _) = generate_hook_with_security(&ctx, None, None, &mut security, false).unwrap();
     insta::assert_snapshot!(output);
@@ -542,6 +545,7 @@ fn snapshot_hook_powershell_with_aliases() {
         shell: &Shells::Powershell,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
+        external_aliases: Default::default(),
     };
     let (output, _) = generate_hook_with_security(&ctx, None, None, &mut security, false).unwrap();
     insta::assert_snapshot!(output);
@@ -569,6 +573,7 @@ fn snapshot_hook_bash_with_aliases() {
         shell: &Shells::Bash,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
+        external_aliases: Default::default(),
     };
     let (output, _) = generate_hook_with_security(&ctx, None, None, &mut security, false).unwrap();
     insta::assert_snapshot!(output);
@@ -595,6 +600,7 @@ fn snapshot_hook_fish_transition() {
         shell: &Shells::Fish,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
+        external_aliases: Default::default(),
     };
     let (output, _) =
         generate_hook_with_security(&ctx, Some("old_a,old_b"), None, &mut security, false).unwrap();
@@ -610,6 +616,7 @@ fn snapshot_hook_fish_leaving_project() {
         shell: &Shells::Fish,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
+        external_aliases: Default::default(),
     };
     let (output, _) =
         generate_hook_with_security(&ctx, Some("old_a,old_b"), None, &mut security, false).unwrap();

--- a/crates/am/tests/snapshots/snapshots__snapshot_hook_bash_with_aliases.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_hook_bash_with_aliases.snap
@@ -5,6 +5,6 @@ expression: output
 printf '%s\n' 'am: loaded .aliases'
 printf '%s\n' '  b → cargo build'
 printf '%s\n' '  t → cargo test'
-b() { cargo build "$@"; }
-t() { cargo test "$@"; }
+alias b="cargo build"
+alias t="cargo test"
 export _AM_PROJECT_ALIASES="b,t"

--- a/crates/am/tests/snapshots/snapshots__snapshot_hook_zsh_with_aliases.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_hook_zsh_with_aliases.snap
@@ -5,6 +5,6 @@ expression: output
 printf '%s\n' 'am: loaded .aliases'
 printf '%s\n' '  b → cargo build'
 printf '%s\n' '  t → cargo test'
-b() { cargo build "$@"; }
-t() { cargo test "$@"; }
+alias b="cargo build"
+alias t="cargo test"
 export _AM_PROJECT_ALIASES="b,t"

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_bash_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_bash_simple_profile.snap
@@ -2,8 +2,8 @@
 source: crates/am/tests/snapshots.rs
 expression: output
 ---
-gs() { git status "$@"; }
-ll() { ls -lha "$@"; }
+alias gs="git status"
+alias ll="ls -lha"
 export _AM_ALIASES="gs,ll"
 unset _AM_PROFILE_ALIASES
 

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_zsh_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_zsh_simple_profile.snap
@@ -2,8 +2,8 @@
 source: crates/am/tests/snapshots.rs
 expression: output
 ---
-gs() { git status "$@"; }
-ll() { ls -lha "$@"; }
+alias gs="git status"
+alias ll="ls -lha"
 export _AM_ALIASES="gs,ll"
 unset _AM_PROFILE_ALIASES
 

--- a/crates/am/tests/snapshots/snapshots__snapshot_reload_after_active_set_changed.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_reload_after_active_set_changed.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/am/tests/snapshots.rs
-assertion_line: 295
 expression: output
 ---
 functions -e ct

--- a/crates/am/tests/snapshots/snapshots__snapshot_reload_after_profile_removed.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_reload_after_profile_removed.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/am/tests/snapshots.rs
-assertion_line: 240
 expression: output
 ---
 functions -e cm

--- a/crates/am/tests/snapshots/snapshots__snapshot_reload_bash_after_global_add.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_reload_bash_after_global_add.snap
@@ -2,11 +2,11 @@
 source: crates/am/tests/snapshots.rs
 expression: output
 ---
-unset -f cm
-unset -f cmf
-unset -f gs
-ll() { ls -lha "$@"; }
-cm() { git commit -sm "$@"; }
+unalias cm 2>/dev/null; unset -f cm 2>/dev/null
+unalias cmf 2>/dev/null; unset -f cmf 2>/dev/null
+unalias gs 2>/dev/null; unset -f gs 2>/dev/null
+alias ll="ls -lha"
+alias cm="git commit -sm"
 cmf() { cm feat: "$@"; }
-gs() { git status "$@"; }
+alias gs="git status"
 export _AM_ALIASES="cm,cmf,gs,ll"

--- a/crates/am/tests/snapshots/snapshots__snapshot_reload_bash_switch_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_reload_bash_switch_profile.snap
@@ -2,9 +2,9 @@
 source: crates/am/tests/snapshots.rs
 expression: output
 ---
-unset -f gs
-unset -f cm
-cm() { git commit -sm "$@"; }
+unalias gs 2>/dev/null; unset -f gs 2>/dev/null
+unalias cm 2>/dev/null; unset -f cm 2>/dev/null
+alias cm="git commit -sm"
 cmf() { cm feat: "$@"; }
-gs() { git status "$@"; }
+alias gs="git status"
 export _AM_ALIASES="cm,cmf,gs"

--- a/crates/am/tests/snapshots/snapshots__snapshot_reload_zsh_after_global_add.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_reload_zsh_after_global_add.snap
@@ -2,11 +2,11 @@
 source: crates/am/tests/snapshots.rs
 expression: output
 ---
-unset -f cm
-unset -f cmf
-unset -f gs
-ll() { ls -lha "$@"; }
-cm() { git commit -sm "$@"; }
+unalias cm 2>/dev/null; unset -f cm 2>/dev/null
+unalias cmf 2>/dev/null; unset -f cmf 2>/dev/null
+unalias gs 2>/dev/null; unset -f gs 2>/dev/null
+alias ll="ls -lha"
+alias cm="git commit -sm"
 cmf() { cm feat: "$@"; }
-gs() { git status "$@"; }
+alias gs="git status"
 export _AM_ALIASES="cm,cmf,gs,ll"

--- a/crates/am/tests/snapshots/snapshots__snapshot_reload_zsh_switch_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_reload_zsh_switch_profile.snap
@@ -2,9 +2,9 @@
 source: crates/am/tests/snapshots.rs
 expression: output
 ---
-unset -f gs
-unset -f cm
-cm() { git commit -sm "$@"; }
+unalias gs 2>/dev/null; unset -f gs 2>/dev/null
+unalias cm 2>/dev/null; unset -f cm 2>/dev/null
+alias cm="git commit -sm"
 cmf() { cm feat: "$@"; }
-gs() { git status "$@"; }
+alias gs="git status"
 export _AM_ALIASES="cm,cmf,gs"

--- a/crates/am/tests/zsh_alias_scan.rs
+++ b/crates/am/tests/zsh_alias_scan.rs
@@ -1,8 +1,6 @@
-/// Unit tests for the zsh alias-output parser helper.
-///
-/// Environment-specific / binary-level tests live in `tests/e2e.rs` and are
-/// excluded from the default test run (`#[ignore]`).
-use std::process::Command;
+//! Unit tests for the zsh alias-output parser helper.
+//! Environment-specific / binary-level tests live in `tests/e2e.rs` and are
+//! excluded from the default test run (`#[ignore]`).
 
 /// Parse the raw stdout of `alias` into a list of alias names.
 fn parse_zsh_alias_keys(output: &str) -> Vec<String> {

--- a/crates/am/tests/zsh_alias_scan.rs
+++ b/crates/am/tests/zsh_alias_scan.rs
@@ -1,0 +1,136 @@
+/// Proof-of-concept: `zsh -i -c 'alias'` can enumerate pre-existing aliases.
+///
+/// This test is intentionally environment-specific — it runs against the current
+/// user's real zsh startup files.  It proves that the mechanism works before any
+/// production implementation is added to the crate.
+///
+/// Expected: the test machine has `la='ls -lAh'` defined in ~/.zshrc (or a
+/// sourced plugin).  If that alias is ever removed from the system config the
+/// assertion at the bottom should be updated accordingly.
+use std::process::Command;
+
+/// Proof that the `_AM_DETECTING_ALIASES` guard works: when `am hook` is invoked
+/// while the env var is set (as it happens during alias scanning), the binary must
+/// exit cleanly with no stdout so that `eval "$(...)"` in shell startup scripts
+/// is a no-op — preventing infinite recursion.
+///
+/// Without the guard `am hook zsh` in a directory containing an `.aliases` file
+/// outputs shell code (at minimum a trust warning), which would be eval'd by the
+/// child zsh and could trigger another scan cycle.
+#[test]
+#[ignore]
+fn am_hook_is_silent_when_am_detecting_aliases_guard_is_active() {
+    // Create a directory with a (deliberately untrusted) .aliases file.
+    // Without the guard this would cause `am hook zsh` to emit shell code.
+    let dir = tempfile::tempdir().expect("failed to create temp dir");
+    std::fs::write(
+        dir.path().join(".aliases"),
+        "[aliases]\nb = \"make build\"\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_am"))
+        .args(["hook", "zsh"])
+        .env("_AM_DETECTING_ALIASES", "1")
+        .env_remove("_AM_PROJECT_ALIASES")
+        .env_remove("_AM_PROJECT_PATH")
+        .current_dir(dir.path())
+        .output()
+        .expect("failed to spawn am binary");
+
+    assert!(
+        output.status.success(),
+        "am should exit 0 when the guard is active, got: {}",
+        output.status
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.is_empty(),
+        "am hook must produce no stdout when _AM_DETECTING_ALIASES is set\n\
+         (any output would be eval'd by the shell and could cause recursion)\n\
+         got: {stdout:?}"
+    );
+}
+
+/// Parse the raw stdout of `alias` into a list of alias names.
+///
+/// zsh `alias` output lines follow the grammar:
+///   name=value            (no special chars)
+///   name='quoted value'   (spaces / special chars)
+///   name='it'\''s here'   (embedded single-quote, escaped as `'\''`)
+///
+/// Only the key (left of the first `=`) is needed here.
+fn parse_zsh_alias_keys(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() {
+                return None;
+            }
+            // Everything before the first `=` is the alias name.
+            line.split('=').next().map(|k| k.to_string())
+        })
+        .collect()
+}
+
+#[test]
+fn zsh_interactive_alias_output_contains_la() {
+    // Spawn an interactive zsh, run `alias`, capture stdout.
+    // stderr is inherited (or can be suppressed) – we only process stdout.
+    let output = Command::new("zsh")
+        .args(["-i", "-c", "alias"])
+        .env("_AM_DETECTING_ALIASES", "1") // guard: prevents recursive `am` invocation
+        .output()
+        .expect("failed to spawn zsh — is zsh installed?");
+
+    assert!(
+        output.status.success() || output.status.code() == Some(1),
+        "zsh exited with unexpected status: {}",
+        output.status
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stdout.is_empty(),
+        "zsh produced no alias output — is ~/.zshrc sourced correctly?"
+    );
+
+    let keys = parse_zsh_alias_keys(&stdout);
+
+    // Sanity: should have captured many aliases (interactive zsh loads plugins)
+    assert!(
+        keys.len() > 5,
+        "expected many aliases from interactive zsh, got only {}: check that zsh \
+         sources ~/.zshrc in interactive mode",
+        keys.len()
+    );
+
+    // Concrete proof: `la` must be present (defined as `la='ls -lAh'` in the
+    // user's zsh config).
+    assert!(
+        keys.contains(&"la".to_string()),
+        "`la` alias not found among {} aliases: {:?}",
+        keys.len(),
+        keys
+    );
+}
+
+#[test]
+fn parse_zsh_alias_keys_handles_various_formats() {
+    let raw = r#"
+gs='git status'
+ll='ls -lh'
+complex='it'\''s a value'
+simple=value
+"#;
+
+    let keys = parse_zsh_alias_keys(raw);
+
+    assert!(keys.contains(&"gs".to_string()));
+    assert!(keys.contains(&"ll".to_string()));
+    assert!(keys.contains(&"complex".to_string()));
+    assert!(keys.contains(&"simple".to_string()));
+    assert_eq!(keys.len(), 4);
+}

--- a/crates/am/tests/zsh_alias_scan.rs
+++ b/crates/am/tests/zsh_alias_scan.rs
@@ -1,65 +1,10 @@
-/// Proof-of-concept: `zsh -i -c 'alias'` can enumerate pre-existing aliases.
+/// Unit tests for the zsh alias-output parser helper.
 ///
-/// This test is intentionally environment-specific — it runs against the current
-/// user's real zsh startup files.  It proves that the mechanism works before any
-/// production implementation is added to the crate.
-///
-/// Expected: the test machine has `la='ls -lAh'` defined in ~/.zshrc (or a
-/// sourced plugin).  If that alias is ever removed from the system config the
-/// assertion at the bottom should be updated accordingly.
+/// Environment-specific / binary-level tests live in `tests/e2e.rs` and are
+/// excluded from the default test run (`#[ignore]`).
 use std::process::Command;
 
-/// Proof that the `_AM_DETECTING_ALIASES` guard works: when `am hook` is invoked
-/// while the env var is set (as it happens during alias scanning), the binary must
-/// exit cleanly with no stdout so that `eval "$(...)"` in shell startup scripts
-/// is a no-op — preventing infinite recursion.
-///
-/// Without the guard `am hook zsh` in a directory containing an `.aliases` file
-/// outputs shell code (at minimum a trust warning), which would be eval'd by the
-/// child zsh and could trigger another scan cycle.
-#[test]
-#[ignore]
-fn am_hook_is_silent_when_am_detecting_aliases_guard_is_active() {
-    // Create a directory with a (deliberately untrusted) .aliases file.
-    // Without the guard this would cause `am hook zsh` to emit shell code.
-    let dir = tempfile::tempdir().expect("failed to create temp dir");
-    std::fs::write(
-        dir.path().join(".aliases"),
-        "[aliases]\nb = \"make build\"\n",
-    )
-    .unwrap();
-
-    let output = Command::new(env!("CARGO_BIN_EXE_am"))
-        .args(["hook", "zsh"])
-        .env("_AM_DETECTING_ALIASES", "1")
-        .env_remove("_AM_PROJECT_ALIASES")
-        .env_remove("_AM_PROJECT_PATH")
-        .current_dir(dir.path())
-        .output()
-        .expect("failed to spawn am binary");
-
-    assert!(
-        output.status.success(),
-        "am should exit 0 when the guard is active, got: {}",
-        output.status
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.is_empty(),
-        "am hook must produce no stdout when _AM_DETECTING_ALIASES is set\n\
-         (any output would be eval'd by the shell and could cause recursion)\n\
-         got: {stdout:?}"
-    );
-}
-
 /// Parse the raw stdout of `alias` into a list of alias names.
-///
-/// zsh `alias` output lines follow the grammar:
-///   name=value            (no special chars)
-///   name='quoted value'   (spaces / special chars)
-///   name='it'\''s here'   (embedded single-quote, escaped as `'\''`)
-///
-/// Only the key (left of the first `=`) is needed here.
 fn parse_zsh_alias_keys(output: &str) -> Vec<String> {
     output
         .lines()
@@ -68,53 +13,9 @@ fn parse_zsh_alias_keys(output: &str) -> Vec<String> {
             if line.is_empty() {
                 return None;
             }
-            // Everything before the first `=` is the alias name.
             line.split('=').next().map(|k| k.to_string())
         })
         .collect()
-}
-
-#[test]
-fn zsh_interactive_alias_output_contains_la() {
-    // Spawn an interactive zsh, run `alias`, capture stdout.
-    // stderr is inherited (or can be suppressed) – we only process stdout.
-    let output = Command::new("zsh")
-        .args(["-i", "-c", "alias"])
-        .env("_AM_DETECTING_ALIASES", "1") // guard: prevents recursive `am` invocation
-        .output()
-        .expect("failed to spawn zsh — is zsh installed?");
-
-    assert!(
-        output.status.success() || output.status.code() == Some(1),
-        "zsh exited with unexpected status: {}",
-        output.status
-    );
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    assert!(
-        !stdout.is_empty(),
-        "zsh produced no alias output — is ~/.zshrc sourced correctly?"
-    );
-
-    let keys = parse_zsh_alias_keys(&stdout);
-
-    // Sanity: should have captured many aliases (interactive zsh loads plugins)
-    assert!(
-        keys.len() > 5,
-        "expected many aliases from interactive zsh, got only {}: check that zsh \
-         sources ~/.zshrc in interactive mode",
-        keys.len()
-    );
-
-    // Concrete proof: `la` must be present (defined as `la='ls -lAh'` in the
-    // user's zsh config).
-    assert!(
-        keys.contains(&"la".to_string()),
-        "`la` alias not found among {} aliases: {:?}",
-        keys.len(),
-        keys
-    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #97 — native aliases were silently ignored when a same-named shell function existed, and vice-versa.

- **Root cause**: in zsh/bash, aliases beat functions at lookup time. If `gs()` exists when `alias gs='git status'` is defined, both coexist but only the alias is reachable — and if a function was defined _after_ the alias, the alias would be unreachable instead. Neither side should silently win.
- **Fix**: scan the shell's existing functions (`typeset +f` / `declare -F`) and aliases (`alias`) at `am init` time, then emit cleanup only for confirmed conflicts:
  - `unset -f <name>` before a native alias when a same-named function exists
  - `unalias <name>` before a function when a same-named alias exists
- **Recursion guard**: scans run `zsh -i -c '…'` / `bash -i -c '…'`, which sources startup files and would trigger `am hook` again. A new `_AM_DETECTING_ALIASES` env var causes `am` to exit immediately (no-op `eval`) when set during those subprocesses.
- **`env_vars` module**: centralises all `_AM_*` env var string constants.
- `Zsh` and `Bash` now own their own rendering structs with the conditional cleanup logic; `NixShell` stays as the shared fallback for `brush`.

## Test plan

- [x] Unit tests for `parse_zsh_function_names`, `parse_zsh_alias_names`, `parse_bash_function_names`, `parse_bash_alias_names`
- [x] Unit tests for conditional `unset -f` / `unalias` emission in `Zsh` and `Bash`
- [x] Integration test: `am hook` produces no output when `_AM_DETECTING_ALIASES` is set (recursion guard)
- [x] Snapshot tests updated for new output format
- [x] `cargo clippy --locked --all-targets -- -D warnings` clean