### PR TITLE
feat(init): add --force flag to reinitialise shell aliases

### DIFF
--- a/completions/bash/am.bash
+++ b/completions/bash/am.bash
@@ -573,7 +573,7 @@ _am() {
             return 0
             ;;
         am__subcmd__init)
-            opts="-h -V --help --version bash fish powershell zsh"
+            opts="-f -h -V --force --help --version bash fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/bash/am.bash
+++ b/completions/bash/am.bash
@@ -537,7 +537,7 @@ _am() {
             return 0
             ;;
         am__subcmd__hook)
-            opts="-q -h -V --quiet --help --version bash fish powershell zsh"
+            opts="-q -h -V --quiet --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -573,7 +573,7 @@ _am() {
             return 0
             ;;
         am__subcmd__init)
-            opts="-f -h -V --force --help --version bash fish powershell zsh"
+            opts="-f -h -V --force --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -763,7 +763,7 @@ _am() {
             return 0
             ;;
         am__subcmd__reload)
-            opts="-h -V --help --version bash fish powershell zsh"
+            opts="-h -V --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -803,7 +803,7 @@ _am() {
             return 0
             ;;
         am__subcmd__setup)
-            opts="-h -V --help --version bash fish powershell zsh"
+            opts="-h -V --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/fish/am.fish
+++ b/completions/fish/am.fish
@@ -85,6 +85,7 @@ complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcomman
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "remove" -d 'Remove a profile'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "list" -d 'List all profiles'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand init" -s f -l force -d 'Force re-initialisation: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling `use_abbr`'
 complete -c am -n "__fish_am_using_subcommand init" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'

--- a/completions/powershell/_am.ps1
+++ b/completions/powershell/_am.ps1
@@ -161,6 +161,8 @@ Register-ArgumentCompleter -Native -CommandName 'am' -ScriptBlock {
             break
         }
         'am;init' {
+            [CompletionResult]::new('-f', '-f', [CompletionResultType]::ParameterName, 'Force re-initialisation: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling `use_abbr`')
+            [CompletionResult]::new('--force', '--force', [CompletionResultType]::ParameterName, 'Force re-initialisation: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling `use_abbr`')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')

--- a/completions/zsh/_am
+++ b/completions/zsh/_am
@@ -187,7 +187,7 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help (see more with '\''--help'\'')]' \
 '-V[Print version]' \
 '--version[Print version]' \
-':shell:(bash fish powershell zsh)' \
+':shell:(bash brush fish powershell zsh)' \
 && ret=0
 ;;
 (setup)
@@ -196,7 +196,7 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-':shell:(bash fish powershell zsh)' \
+':shell:(bash brush fish powershell zsh)' \
 && ret=0
 ;;
 (use)
@@ -301,7 +301,7 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-':shell:(bash fish powershell zsh)' \
+':shell:(bash brush fish powershell zsh)' \
 && ret=0
 ;;
 (reload)
@@ -310,7 +310,7 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-':shell:(bash fish powershell zsh)' \
+':shell:(bash brush fish powershell zsh)' \
 && ret=0
 ;;
 (help)

--- a/completions/zsh/_am
+++ b/completions/zsh/_am
@@ -181,6 +181,8 @@ esac
 ;;
 (init)
 _arguments "${_arguments_options[@]}" : \
+'-f[Force re-initialisation\: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling \`use_abbr\`]' \
+'--force[Force re-initialisation\: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling \`use_abbr\`]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
 '-V[Print version]' \

--- a/crates/am/build.rs
+++ b/crates/am/build.rs
@@ -4,11 +4,11 @@ use clap_complete::{
     generate_to,
 };
 
-/// Minimal stub of the Shells enum for build-script shell-completion generation.
+/// Minimal stub of the Shell enum for build-script shell-completion generation.
 /// The real implementation lives in src/shell/shell.rs.
 pub mod shell {
     #[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
-    pub enum Shells {
+    pub enum Shell {
         Bash,
         Fish,
         Powershell,

--- a/crates/am/build.rs
+++ b/crates/am/build.rs
@@ -4,16 +4,8 @@ use clap_complete::{
     generate_to,
 };
 
-/// Minimal stub of the Shell enum for build-script shell-completion generation.
-/// The real implementation lives in src/shell/shell.rs.
 pub mod shell {
-    #[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
-    pub enum Shell {
-        Bash,
-        Fish,
-        Powershell,
-        Zsh,
-    }
+    include!("src/shell/shell_enum.rs");
 }
 
 include!("src/cli.rs");

--- a/crates/am/src/bin/am.rs
+++ b/crates/am/src/bin/am.rs
@@ -384,7 +384,7 @@ fn main() -> anyhow::Result<()> {
             execute_effects(&mut model, &result.effects)?;
             return Ok(());
         }
-        Commands::Init { shell } => Message::InitShell(shell.clone()),
+        Commands::Init { shell, force } => Message::InitShell(shell.clone(), *force),
         Commands::Hook { shell, quiet } => Message::Hook(shell.clone(), *quiet),
         Commands::Reload { shell } => Message::Reload(shell.clone()),
     };

--- a/crates/am/src/cli.rs
+++ b/crates/am/src/cli.rs
@@ -77,7 +77,14 @@ pub enum Commands {
     ///
     /// Note: Nushell is not yet supported.
     #[command(verbatim_doc_comment)]
-    Init { shell: Shells },
+    Init {
+        /// Force re-initialisation: unload all previously tracked aliases (both
+        /// alias and function forms) before re-loading. Use after config changes
+        /// such as toggling `use_abbr`.
+        #[arg(short = 'f', long)]
+        force: bool,
+        shell: Shells,
+    },
 
     /// Guided setup — adds amoxide to your shell profile
     Setup { shell: Shells },

--- a/crates/am/src/cli.rs
+++ b/crates/am/src/cli.rs
@@ -1,6 +1,6 @@
 pub use clap::{Args, Parser, Subcommand};
 
-use crate::shell::Shells;
+use crate::shell::Shell;
 
 /// amoxide — the alias manager
 ///
@@ -83,11 +83,11 @@ pub enum Commands {
         /// such as toggling `use_abbr`.
         #[arg(short = 'f', long)]
         force: bool,
-        shell: Shells,
+        shell: Shell,
     },
 
     /// Guided setup — adds amoxide to your shell profile
-    Setup { shell: Shells },
+    Setup { shell: Shell },
 
     /// Shortcut for `am profile use` — toggle one or more profiles
     #[command(alias = "u")]
@@ -134,12 +134,12 @@ pub enum Commands {
         /// Suppress info and warning messages (still unloads/loads aliases)
         #[arg(short, long)]
         quiet: bool,
-        shell: Shells,
+        shell: Shell,
     },
 
     /// Internal: called by the am wrapper to reload profile aliases after switching
     #[command(hide = true)]
-    Reload { shell: Shells },
+    Reload { shell: Shell },
 }
 
 #[derive(Subcommand)]

--- a/crates/am/src/hook.rs
+++ b/crates/am/src/hook.rs
@@ -212,7 +212,7 @@ pub fn generate_hook_with_security(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::shell::Shells;
+    use crate::shell::Shell;
     use std::path::{Path, PathBuf};
 
     /// Builder for hook test fixtures.
@@ -296,7 +296,7 @@ mod tests {
             self.dir.path().join(rel_path)
         }
 
-        fn run(&mut self, shell: &Shells, cwd: &Path, prev: Option<&str>) -> (String, bool) {
+        fn run(&mut self, shell: &Shell, cwd: &Path, prev: Option<&str>) -> (String, bool) {
             use crate::config::ShellsTomlConfig;
             let cfg = ShellsTomlConfig::default();
             let ctx = ShellContext {
@@ -328,7 +328,7 @@ mod tests {
             .setup();
 
         let cwd = t.root();
-        let (output, _) = t.run(&Shells::Fish, &cwd, None);
+        let (output, _) = t.run(&Shell::Fish, &cwd, None);
         assert!(output.contains("alias b \"make build\""));
         assert!(output.contains("alias t \"make test\""));
         assert!(output.contains(env_vars::AM_PROJECT_ALIASES));
@@ -339,7 +339,7 @@ mod tests {
         let mut t = TestBed::new().setup();
 
         let cwd = t.root();
-        let (output, _) = t.run(&Shells::Fish, &cwd, Some("old1,old2"));
+        let (output, _) = t.run(&Shell::Fish, &cwd, Some("old1,old2"));
         assert!(output.contains("functions -e old1"));
         assert!(output.contains("functions -e old2"));
         assert!(output.contains("set -e _AM_PROJECT_ALIASES"));
@@ -350,7 +350,7 @@ mod tests {
         let mut t = TestBed::new().setup();
 
         let cwd = t.root();
-        let (output, _) = t.run(&Shells::Fish, &cwd, None);
+        let (output, _) = t.run(&Shell::Fish, &cwd, None);
         assert!(output.is_empty());
     }
 
@@ -362,7 +362,7 @@ mod tests {
             .setup();
 
         let cwd = t.root();
-        let (output, _) = t.run(&Shells::Fish, &cwd, Some("old1,old2"));
+        let (output, _) = t.run(&Shell::Fish, &cwd, Some("old1,old2"));
         assert!(output.contains("functions -e old1"));
         assert!(output.contains("functions -e old2"));
         assert!(output.contains("alias new1 \"echo new\""));
@@ -377,7 +377,7 @@ mod tests {
             .setup();
 
         let cwd = t.root();
-        let (output, _) = t.run(&Shells::Zsh, &cwd, Some("old"));
+        let (output, _) = t.run(&Shell::Zsh, &cwd, Some("old"));
         assert!(output.contains("unset -f old"));
         assert!(output.contains("alias b=\"make build\""));
         assert!(output.contains("export _AM_PROJECT_ALIASES="));
@@ -391,13 +391,13 @@ mod tests {
             .setup();
 
         let cwd = t.root();
-        let (output, _) = t.run(&Shells::Fish, &cwd, None);
+        let (output, _) = t.run(&Shell::Fish, &cwd, None);
         assert!(output.contains("alias b \"make build\""));
         assert!(!output.contains("alias t"));
 
         t.update_aliases("[aliases]\nb = \"make build\"\nt = \"make test\"\n");
 
-        let (output, _) = t.run(&Shells::Fish, &cwd, Some("b"));
+        let (output, _) = t.run(&Shell::Fish, &cwd, Some("b"));
         assert!(output.contains("functions -e b"));
         assert!(output.contains("alias b \"make build\""));
         assert!(output.contains("alias t \"make test\""));
@@ -412,13 +412,13 @@ mod tests {
             .setup();
 
         let cwd = t.root();
-        let (output, _) = t.run(&Shells::Fish, &cwd, None);
+        let (output, _) = t.run(&Shell::Fish, &cwd, None);
         assert!(output.contains("alias b"));
         assert!(output.contains("alias t"));
 
         t.update_aliases("[aliases]\nb = \"make build\"\n");
 
-        let (output, _) = t.run(&Shells::Fish, &cwd, Some("b,t"));
+        let (output, _) = t.run(&Shell::Fish, &cwd, Some("b,t"));
         assert!(output.contains("functions -e b"));
         assert!(output.contains("functions -e t"));
         assert!(output.contains("alias b \"make build\""));
@@ -434,7 +434,7 @@ mod tests {
             .setup();
 
         let cwd = t.root();
-        let (output, _) = t.run(&Shells::Bash, &cwd, Some("old"));
+        let (output, _) = t.run(&Shell::Bash, &cwd, Some("old"));
         assert!(output.contains("unset -f old"));
         assert!(output.contains("alias b=\"make build\""));
         assert!(output.contains("export _AM_PROJECT_ALIASES="));
@@ -449,7 +449,7 @@ mod tests {
             .setup();
 
         let sub = t.subdir("src/deep");
-        let (output, _) = t.run(&Shells::Fish, &sub, None);
+        let (output, _) = t.run(&Shell::Fish, &sub, None);
         assert!(
             output.contains("alias b \"make build\""),
             "should load aliases from parent .aliases, got: {output}"
@@ -468,7 +468,7 @@ mod tests {
             .setup();
 
         let cwd = t.root();
-        let (output, changed) = t.run(&Shells::Fish, &cwd, None);
+        let (output, changed) = t.run(&Shell::Fish, &cwd, None);
         assert!(!changed);
         assert!(output.contains("alias b \"make build\""));
         assert!(output.contains("am: loaded .aliases"));
@@ -481,7 +481,7 @@ mod tests {
             .setup();
 
         let cwd = t.root();
-        let (output, changed) = t.run(&Shells::Fish, &cwd, None);
+        let (output, changed) = t.run(&Shell::Fish, &cwd, None);
         assert!(!changed);
         assert!(!output.contains("alias b"));
         assert!(output.contains("am: .aliases found but not trusted"));
@@ -496,7 +496,7 @@ mod tests {
             .setup();
 
         let cwd = t.root();
-        let (output, changed) = t.run(&Shells::Fish, &cwd, None);
+        let (output, changed) = t.run(&Shell::Fish, &cwd, None);
         assert!(!changed);
         assert!(!output.contains("alias b"));
         assert!(!output.contains("am:"));
@@ -510,7 +510,7 @@ mod tests {
             .setup();
 
         let cwd = t.root();
-        let (output, changed) = t.run(&Shells::Fish, &cwd, None);
+        let (output, changed) = t.run(&Shell::Fish, &cwd, None);
         assert!(changed);
         assert!(!output.contains("alias b"));
         assert!(output.contains("modified since last trusted"));
@@ -521,7 +521,7 @@ mod tests {
         let mut t = TestBed::new().setup();
 
         let cwd = t.root();
-        let (output, _) = t.run(&Shells::Fish, &cwd, Some("old1,old2"));
+        let (output, _) = t.run(&Shell::Fish, &cwd, Some("old1,old2"));
         assert!(output.contains("functions -e old1"));
         assert!(output.contains("functions -e old2"));
         assert!(output.contains("am: unloaded .aliases"));
@@ -537,7 +537,7 @@ mod tests {
             .setup();
 
         let sub = t.subdir("src");
-        let (output, _) = t.run(&Shells::Fish, &sub, None);
+        let (output, _) = t.run(&Shell::Fish, &sub, None);
         assert!(
             !output.contains("am:"),
             "should not show warning for parent .aliases, got: {output}"
@@ -553,7 +553,7 @@ mod tests {
             .setup();
 
         let sub = t.subdir("src");
-        let (output, _) = t.run(&Shells::Fish, &sub, None);
+        let (output, _) = t.run(&Shell::Fish, &sub, None);
         assert!(output.contains("alias b \"make build\""));
         assert!(
             !output.contains("am: loaded"),
@@ -575,7 +575,7 @@ mod tests {
         let cwd = t.root();
 
         // First run: load c:l, c wrapper is emitted
-        let (output, _) = t.run(&Shells::Fish, &cwd, None);
+        let (output, _) = t.run(&Shell::Fish, &cwd, None);
         assert!(
             output.contains("function c"),
             "first run should emit c wrapper"
@@ -586,7 +586,7 @@ mod tests {
         t.update_aliases("[subcommands]\n\"c:l\" = [\"clippy\"]\n\"c:t\" = [\"test\"]\n");
 
         // Second run: prev="c" (already loaded), but file has new content
-        let (output, _) = t.run(&Shells::Fish, &cwd, Some("c"));
+        let (output, _) = t.run(&Shell::Fish, &cwd, Some("c"));
         assert!(
             output.contains("function c"),
             "hook must re-emit c wrapper after new subcommand added, got: {output}"
@@ -608,7 +608,7 @@ mod tests {
             .setup();
 
         let cwd = t.root();
-        let (output, _) = t.run(&Shells::Bash, &cwd, None);
+        let (output, _) = t.run(&Shell::Bash, &cwd, None);
         assert!(output.contains("alias b=\"make build\""));
         assert!(output.contains("jj() {"));
         assert!(output.contains("ab) shift; command jj abandon"));

--- a/crates/am/src/init.rs
+++ b/crates/am/src/init.rs
@@ -96,6 +96,30 @@ pub fn generate_init(
     lines.join("\n")
 }
 
+/// Like [`generate_init`] but prepends force-cleanup lines for `prev_names`.
+/// Each name is unloaded using all possible shell forms before the normal init runs.
+/// Intended for testing; production code reads prev_names from env vars in `update.rs`.
+pub fn generate_force_init(
+    ctx: &ShellContext,
+    global_aliases: &AliasSet,
+    profile_aliases: &AliasSet,
+    subcommands: &SubcommandSet,
+    prev_names: &[String],
+) -> String {
+    let shell_impl = ctx.shell.clone().as_shell(
+        ctx.cfg,
+        Default::default(),
+        Default::default(),
+    );
+    let mut output = String::new();
+    for name in prev_names {
+        output.push_str(&shell_impl.force_unalias(name));
+        output.push('\n');
+    }
+    output.push_str(&generate_init(ctx, global_aliases, profile_aliases, subcommands));
+    output
+}
+
 /// Generate shell code to reload all aliases (global + profile) after a mutation.
 /// Unloads old aliases, loads new ones, updates the tracking env var.
 pub fn generate_reload(

--- a/crates/am/src/init.rs
+++ b/crates/am/src/init.rs
@@ -1,5 +1,5 @@
 use crate::env_vars;
-use crate::shell::{ShellContext, Shell};
+use crate::shell::{Shell, ShellContext};
 use crate::subcommand::{group_by_program, SubcommandSet};
 use crate::AliasSet;
 
@@ -106,11 +106,10 @@ pub fn generate_force_init(
     subcommands: &SubcommandSet,
     prev_names: &[String],
 ) -> String {
-    let shell_impl = ctx.shell.clone().as_shell(
-        ctx.cfg,
-        Default::default(),
-        Default::default(),
-    );
+    let shell_impl = ctx
+        .shell
+        .clone()
+        .as_shell(ctx.cfg, Default::default(), Default::default());
     let mut output = String::new();
     for name in prev_names {
         output.push_str(&shell_impl.force_unalias(name));
@@ -121,7 +120,12 @@ pub fn generate_force_init(
     output.push('\n');
     output.push_str(&shell_impl.unset_env(crate::env_vars::AM_PROJECT_PATH));
     output.push('\n');
-    output.push_str(&generate_init(ctx, global_aliases, profile_aliases, subcommands));
+    output.push_str(&generate_init(
+        ctx,
+        global_aliases,
+        profile_aliases,
+        subcommands,
+    ));
     output
 }
 

--- a/crates/am/src/init.rs
+++ b/crates/am/src/init.rs
@@ -1,5 +1,5 @@
 use crate::env_vars;
-use crate::shell::{ShellContext, Shells};
+use crate::shell::{ShellContext, Shell};
 use crate::subcommand::{group_by_program, SubcommandSet};
 use crate::AliasSet;
 
@@ -203,36 +203,36 @@ pub fn generate_reload(
     lines.join("\n")
 }
 
-fn shell_script(template: &str, shell: &Shells) -> String {
+fn shell_script(template: &str, shell: &Shell) -> String {
     template.replace("__SHELL__", &shell.to_string())
 }
 
-fn am_wrapper(shell: &Shells) -> String {
+fn am_wrapper(shell: &Shell) -> String {
     match shell {
-        Shells::Bash | Shells::Brush => shell_script(WRAPPER_BASH, shell),
-        Shells::Fish => shell_script(WRAPPER_FISH, shell),
-        Shells::Powershell => shell_script(WRAPPER_PS1, shell),
-        Shells::Zsh => shell_script(WRAPPER_ZSH, shell),
+        Shell::Bash | Shell::Brush => shell_script(WRAPPER_BASH, shell),
+        Shell::Fish => shell_script(WRAPPER_FISH, shell),
+        Shell::Powershell => shell_script(WRAPPER_PS1, shell),
+        Shell::Zsh => shell_script(WRAPPER_ZSH, shell),
     }
 }
 
-fn cd_hook_setup(shell: &Shells) -> String {
+fn cd_hook_setup(shell: &Shell) -> String {
     match shell {
-        Shells::Bash | Shells::Brush => shell_script(HOOK_BASH, shell),
-        Shells::Fish => shell_script(HOOK_FISH, shell),
-        Shells::Powershell => shell_script(HOOK_PS1, shell),
-        Shells::Zsh => shell_script(HOOK_ZSH, shell),
+        Shell::Bash | Shell::Brush => shell_script(HOOK_BASH, shell),
+        Shell::Fish => shell_script(HOOK_FISH, shell),
+        Shell::Powershell => shell_script(HOOK_PS1, shell),
+        Shell::Zsh => shell_script(HOOK_ZSH, shell),
     }
 }
 
-fn completions(shell: &Shells) -> String {
+fn completions(shell: &Shell) -> String {
     match shell {
-        Shells::Bash | Shells::Brush => {
+        Shell::Bash | Shell::Brush => {
             include_str!(concat!(env!("OUT_DIR"), "/am.bash")).to_string()
         }
-        Shells::Fish => COMPLETIONS_FISH.to_string(),
-        Shells::Powershell => powershell_completions(),
-        Shells::Zsh => COMPLETIONS_ZSH.to_string(),
+        Shell::Fish => COMPLETIONS_FISH.to_string(),
+        Shell::Powershell => powershell_completions(),
+        Shell::Zsh => COMPLETIONS_ZSH.to_string(),
     }
 }
 
@@ -273,7 +273,7 @@ mod tests {
     static DEFAULT_CFG: std::sync::LazyLock<ShellsTomlConfig> =
         std::sync::LazyLock::new(ShellsTomlConfig::default);
 
-    fn default_ctx(shell: &Shells) -> ShellContext<'_> {
+    fn default_ctx(shell: &Shell) -> ShellContext<'_> {
         ShellContext {
             shell,
             cfg: &DEFAULT_CFG,
@@ -306,7 +306,7 @@ mod tests {
     fn test_fish_init_contains_aliases() {
         let aliases = test_aliases();
         let output = generate_init(
-            &default_ctx(&Shells::Fish),
+            &default_ctx(&Shell::Fish),
             &AliasSet::default(),
             &aliases,
             &SubcommandSet::new(),
@@ -319,7 +319,7 @@ mod tests {
     fn test_fish_init_tracks_all_aliases() {
         let aliases = test_aliases();
         let output = generate_init(
-            &default_ctx(&Shells::Fish),
+            &default_ctx(&Shell::Fish),
             &AliasSet::default(),
             &aliases,
             &SubcommandSet::new(),
@@ -331,7 +331,7 @@ mod tests {
     fn test_fish_init_contains_wrapper() {
         let aliases = test_aliases();
         let output = generate_init(
-            &default_ctx(&Shells::Fish),
+            &default_ctx(&Shell::Fish),
             &AliasSet::default(),
             &aliases,
             &SubcommandSet::new(),
@@ -346,7 +346,7 @@ mod tests {
     fn test_fish_init_contains_cd_hook() {
         let aliases = test_aliases();
         let output = generate_init(
-            &default_ctx(&Shells::Fish),
+            &default_ctx(&Shell::Fish),
             &AliasSet::default(),
             &aliases,
             &SubcommandSet::new(),
@@ -359,7 +359,7 @@ mod tests {
     fn test_zsh_init_contains_aliases() {
         let aliases = test_aliases();
         let output = generate_init(
-            &default_ctx(&Shells::Zsh),
+            &default_ctx(&Shell::Zsh),
             &AliasSet::default(),
             &aliases,
             &SubcommandSet::new(),
@@ -372,7 +372,7 @@ mod tests {
     fn test_zsh_init_contains_wrapper() {
         let aliases = test_aliases();
         let output = generate_init(
-            &default_ctx(&Shells::Zsh),
+            &default_ctx(&Shell::Zsh),
             &AliasSet::default(),
             &aliases,
             &SubcommandSet::new(),
@@ -387,7 +387,7 @@ mod tests {
     fn test_zsh_init_contains_cd_hook() {
         let aliases = test_aliases();
         let output = generate_init(
-            &default_ctx(&Shells::Zsh),
+            &default_ctx(&Shell::Zsh),
             &AliasSet::default(),
             &aliases,
             &SubcommandSet::new(),
@@ -399,7 +399,7 @@ mod tests {
     #[test]
     fn test_init_empty_no_tracking_var() {
         let output = generate_init(
-            &default_ctx(&Shells::Fish),
+            &default_ctx(&Shell::Fish),
             &AliasSet::default(),
             &AliasSet::default(),
             &SubcommandSet::new(),
@@ -412,7 +412,7 @@ mod tests {
     fn test_reload_unloads_old_and_loads_new() {
         let aliases = test_aliases();
         let output = generate_reload(
-            &default_ctx(&Shells::Fish),
+            &default_ctx(&Shell::Fish),
             &AliasSet::default(),
             &aliases,
             &SubcommandSet::new(),
@@ -429,7 +429,7 @@ mod tests {
     fn test_reload_zsh_unloads_with_unset_f() {
         let aliases = test_aliases();
         let output = generate_reload(
-            &default_ctx(&Shells::Zsh),
+            &default_ctx(&Shell::Zsh),
             &AliasSet::default(),
             &aliases,
             &SubcommandSet::new(),
@@ -443,7 +443,7 @@ mod tests {
     fn test_reload_no_previous() {
         let aliases = test_aliases();
         let output = generate_reload(
-            &default_ctx(&Shells::Fish),
+            &default_ctx(&Shell::Fish),
             &AliasSet::default(),
             &aliases,
             &SubcommandSet::new(),
@@ -456,7 +456,7 @@ mod tests {
     #[test]
     fn test_reload_to_empty_clears_tracking() {
         let output = generate_reload(
-            &default_ctx(&Shells::Fish),
+            &default_ctx(&Shell::Fish),
             &AliasSet::default(),
             &AliasSet::default(),
             &SubcommandSet::new(),
@@ -474,7 +474,7 @@ mod tests {
             crate::TomlAlias::Command("ls -lha".to_string()),
         );
         let output = generate_init(
-            &default_ctx(&Shells::Fish),
+            &default_ctx(&Shell::Fish),
             &globals,
             &AliasSet::default(),
             &SubcommandSet::new(),
@@ -491,7 +491,7 @@ mod tests {
         );
         let aliases = test_aliases();
         let output = generate_init(
-            &default_ctx(&Shells::Fish),
+            &default_ctx(&Shell::Fish),
             &globals,
             &aliases,
             &SubcommandSet::new(),
@@ -512,7 +512,7 @@ mod tests {
             crate::TomlAlias::Command("ls -lha".to_string()),
         );
         let output = generate_reload(
-            &default_ctx(&Shells::Fish),
+            &default_ctx(&Shell::Fish),
             &globals,
             &AliasSet::default(),
             &SubcommandSet::new(),
@@ -526,7 +526,7 @@ mod tests {
     fn test_bash_init_contains_aliases() {
         let aliases = test_aliases();
         let output = generate_init(
-            &default_ctx(&Shells::Bash),
+            &default_ctx(&Shell::Bash),
             &AliasSet::default(),
             &aliases,
             &SubcommandSet::new(),
@@ -539,7 +539,7 @@ mod tests {
     fn test_bash_init_contains_wrapper() {
         let aliases = test_aliases();
         let output = generate_init(
-            &default_ctx(&Shells::Bash),
+            &default_ctx(&Shell::Bash),
             &AliasSet::default(),
             &aliases,
             &SubcommandSet::new(),
@@ -554,7 +554,7 @@ mod tests {
     fn test_bash_init_contains_cd_hook() {
         let aliases = test_aliases();
         let output = generate_init(
-            &default_ctx(&Shells::Bash),
+            &default_ctx(&Shell::Bash),
             &AliasSet::default(),
             &aliases,
             &SubcommandSet::new(),
@@ -569,7 +569,7 @@ mod tests {
     fn test_reload_bash_unloads_with_unset_f() {
         let aliases = test_aliases();
         let output = generate_reload(
-            &default_ctx(&Shells::Bash),
+            &default_ctx(&Shell::Bash),
             &AliasSet::default(),
             &aliases,
             &SubcommandSet::new(),
@@ -583,7 +583,7 @@ mod tests {
     fn test_bash_init_contains_subcommand_wrapper() {
         let subs = test_subcommands();
         let output = generate_init(
-            &default_ctx(&Shells::Bash),
+            &default_ctx(&Shell::Bash),
             &AliasSet::default(),
             &AliasSet::default(),
             &subs,
@@ -597,7 +597,7 @@ mod tests {
     fn test_fish_init_contains_subcommand_wrapper() {
         let subs = test_subcommands();
         let output = generate_init(
-            &default_ctx(&Shells::Fish),
+            &default_ctx(&Shell::Fish),
             &AliasSet::default(),
             &AliasSet::default(),
             &subs,
@@ -613,7 +613,7 @@ mod tests {
         aliases.insert("jj".into(), TomlAlias::Command("just-a-joke".into()));
         let subs = test_subcommands();
         let output = generate_init(
-            &default_ctx(&Shells::Bash),
+            &default_ctx(&Shell::Bash),
             &aliases,
             &AliasSet::default(),
             &subs,
@@ -631,7 +631,7 @@ mod tests {
     fn test_init_subcommand_tracked_in_am_aliases() {
         let subs = test_subcommands();
         let output = generate_init(
-            &default_ctx(&Shells::Fish),
+            &default_ctx(&Shell::Fish),
             &AliasSet::default(),
             &AliasSet::default(),
             &subs,
@@ -647,7 +647,7 @@ mod tests {
         };
         let cwd = std::path::Path::new("/tmp");
         let ctx = ShellContext {
-            shell: &Shells::Fish,
+            shell: &Shell::Fish,
             cfg: &cfg,
             cwd,
             external_functions: Default::default(),
@@ -670,7 +670,7 @@ mod tests {
         };
         let cwd = std::path::Path::new("/tmp");
         let ctx = ShellContext {
-            shell: &Shells::Fish,
+            shell: &Shell::Fish,
             cfg: &cfg,
             cwd,
             external_functions: Default::default(),

--- a/crates/am/src/init.rs
+++ b/crates/am/src/init.rs
@@ -116,6 +116,11 @@ pub fn generate_force_init(
         output.push_str(&shell_impl.force_unalias(name));
         output.push('\n');
     }
+    // Clear project-alias tracking so __am_hook reloads them fresh.
+    output.push_str(&shell_impl.unset_env(crate::env_vars::AM_PROJECT_ALIASES));
+    output.push('\n');
+    output.push_str(&shell_impl.unset_env(crate::env_vars::AM_PROJECT_PATH));
+    output.push('\n');
     output.push_str(&generate_init(ctx, global_aliases, profile_aliases, subcommands));
     output
 }

--- a/crates/am/src/messages.rs
+++ b/crates/am/src/messages.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use crate::exchange::ImportPayload;
-use crate::shell::Shells;
+use crate::shell::Shell;
 
 #[derive(Debug, PartialEq)]
 pub enum AliasTarget {
@@ -34,9 +34,9 @@ pub enum Message {
         new_command: String,
         raw: bool,
     },
-    InitShell(Shells, bool),
-    Hook(Shells, bool),
-    Reload(Shells),
+    InitShell(Shell, bool),
+    Hook(Shell, bool),
+    Reload(Shell),
 
     ToggleProfiles(Vec<String>),
     UseProfilesAt(Vec<String>, usize),

--- a/crates/am/src/messages.rs
+++ b/crates/am/src/messages.rs
@@ -34,7 +34,7 @@ pub enum Message {
         new_command: String,
         raw: bool,
     },
-    InitShell(Shells),
+    InitShell(Shells, bool),
     Hook(Shells, bool),
     Reload(Shells),
 

--- a/crates/am/src/setup.rs
+++ b/crates/am/src/setup.rs
@@ -2,7 +2,7 @@ use std::io::{BufRead, Write};
 use std::path::PathBuf;
 
 use crate::prompt::{ask_user, Answer};
-use crate::shell::Shells;
+use crate::shell::Shell;
 
 /// Ask PowerShell for its $PROFILE path by shelling out.
 /// Works for both PS 5.1 (WindowsPowerShell) and PS 7+ (PowerShell).
@@ -25,26 +25,26 @@ pub fn detect_powershell_profile() -> Option<PathBuf> {
 }
 
 /// Returns the profile file path and the init line for the given shell.
-fn shell_config(shell: &Shells) -> (PathBuf, &'static str) {
+fn shell_config(shell: &Shell) -> (PathBuf, &'static str) {
     match shell {
-        Shells::Bash => {
+        Shell::Bash => {
             let home = crate::dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
             (home.join(".bashrc"), r#"eval "$(am init bash)""#)
         }
-        Shells::Brush => {
+        Shell::Brush => {
             let home = crate::dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
             (home.join(".brushrc"), r#"eval "$(am init brush)""#)
         }
-        Shells::Fish => {
+        Shell::Fish => {
             let mut path = dirs_lite::config_dir().unwrap_or_else(|| PathBuf::from(".config"));
             path.push("fish/config.fish");
             (path, "am init fish | source")
         }
-        Shells::Zsh => {
+        Shell::Zsh => {
             let home = crate::dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
             (home.join(".zshrc"), r#"eval "$(am init zsh)""#)
         }
-        Shells::Powershell => {
+        Shell::Powershell => {
             let path = detect_powershell_profile().unwrap_or_else(|| {
                 let home = crate::dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
                 home.join("Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1")
@@ -58,13 +58,13 @@ fn shell_config(shell: &Shells) -> (PathBuf, &'static str) {
 }
 
 /// Returns how to reload the shell after setup.
-fn reload_hint(shell: &Shells, profile_path: &std::path::Path) -> String {
+fn reload_hint(shell: &Shell, profile_path: &std::path::Path) -> String {
     let path = profile_path.display();
     match shell {
-        Shells::Bash | Shells::Brush => format!("Run: source {path}"),
-        Shells::Fish => format!("Run: source {path}"),
-        Shells::Zsh => format!("Run: source {path}"),
-        Shells::Powershell => format!(
+        Shell::Bash | Shell::Brush => format!("Run: source {path}"),
+        Shell::Fish => format!("Run: source {path}"),
+        Shell::Zsh => format!("Run: source {path}"),
+        Shell::Powershell => format!(
             "Reload your profile:\n\n  . \"{path}\"\n\n\
             If you get a \"running scripts is disabled\" error, run this first:\n\n  \
             Set-ExecutionPolicy -Scope CurrentUser RemoteSigned"
@@ -73,7 +73,7 @@ fn reload_hint(shell: &Shells, profile_path: &std::path::Path) -> String {
 }
 
 /// Run the interactive setup for the given shell.
-pub fn run_setup(shell: &Shells) -> anyhow::Result<()> {
+pub fn run_setup(shell: &Shell) -> anyhow::Result<()> {
     let (profile_path, init_line) = shell_config(shell);
     run_setup_inner(
         shell,
@@ -85,7 +85,7 @@ pub fn run_setup(shell: &Shells) -> anyhow::Result<()> {
 
 /// Core setup logic, testable with custom path and reader.
 fn run_setup_inner(
-    shell: &Shells,
+    shell: &Shell,
     profile_path: &std::path::Path,
     init_line: &str,
     reader: &mut dyn BufRead,
@@ -165,7 +165,7 @@ mod tests {
         std::fs::write(&profile, "# existing config\n").unwrap();
 
         let mut reader = Cursor::new(input.to_vec());
-        run_setup_inner(&Shells::Zsh, &profile, INIT_LINE, &mut reader).unwrap();
+        run_setup_inner(&Shell::Zsh, &profile, INIT_LINE, &mut reader).unwrap();
 
         std::fs::read_to_string(&profile).unwrap()
     }
@@ -208,7 +208,7 @@ mod tests {
 
         let init_line = r#"eval "$(am init bash)""#;
         let mut reader = Cursor::new(b"y\n".to_vec());
-        run_setup_inner(&Shells::Bash, &profile, init_line, &mut reader).unwrap();
+        run_setup_inner(&Shell::Bash, &profile, init_line, &mut reader).unwrap();
 
         let content = std::fs::read_to_string(&profile).unwrap();
         assert!(content.contains("am init bash"), "got: {content}");
@@ -221,7 +221,7 @@ mod tests {
         let profile = dir.path().join("subdir/.zshrc");
 
         let mut reader = Cursor::new(b"y\n");
-        run_setup_inner(&Shells::Zsh, &profile, INIT_LINE, &mut reader).unwrap();
+        run_setup_inner(&Shell::Zsh, &profile, INIT_LINE, &mut reader).unwrap();
 
         if profile.exists() {
             let content = std::fs::read_to_string(&profile).unwrap();

--- a/crates/am/src/shell/bash.rs
+++ b/crates/am/src/shell/bash.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use super::{has_template_args, quote_cmd, substitute_nix, NixShell, Shell};
+use super::{has_template_args, quote_cmd, substitute_nix, NixShell, ShellAdapter};
 use crate::alias::AliasEntry;
 
 #[derive(Debug, Default)]
@@ -20,7 +20,7 @@ impl Bash {
     }
 }
 
-impl Shell for Bash {
+impl ShellAdapter for Bash {
     fn unalias(&self, alias_name: &str) -> String {
         NixShell.unalias(alias_name)
     }

--- a/crates/am/src/shell/brush.rs
+++ b/crates/am/src/shell/brush.rs
@@ -1,10 +1,10 @@
-use super::{NixShell, Shell};
+use super::{NixShell, ShellAdapter};
 use crate::alias::AliasEntry;
 
 #[derive(Debug, Default)]
 pub struct Brush;
 
-impl Shell for Brush {
+impl ShellAdapter for Brush {
     fn unalias(&self, alias_name: &str) -> String {
         NixShell.unalias(alias_name)
     }

--- a/crates/am/src/shell/fish.rs
+++ b/crates/am/src/shell/fish.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 
 use super::{
-    build_wrapper_trie, has_template_args, quote_cmd, substitute_fish, Shell, WrapperNode,
+    build_wrapper_trie, has_template_args, quote_cmd, substitute_fish, ShellAdapter, WrapperNode,
     TEMPLATE_RE,
 };
 use crate::alias::AliasEntry;
@@ -111,7 +111,7 @@ impl Fish {
     }
 }
 
-impl Shell for Fish {
+impl ShellAdapter for Fish {
     fn unalias(&self, alias_name: &str) -> String {
         if self.use_abbr {
             format!("abbr --erase {alias_name}")

--- a/crates/am/src/shell/fish.rs
+++ b/crates/am/src/shell/fish.rs
@@ -432,15 +432,27 @@ mod tests {
     fn test_fish_force_unalias_no_abbr() {
         let fish = Fish { use_abbr: false };
         let out = fish.force_unalias("foo");
-        assert!(out.contains("functions -e foo"), "missing functions -e: {out}");
-        assert!(out.contains("abbr --query foo; and abbr --erase foo"), "missing abbr guard: {out}");
+        assert!(
+            out.contains("functions -e foo"),
+            "missing functions -e: {out}"
+        );
+        assert!(
+            out.contains("abbr --query foo; and abbr --erase foo"),
+            "missing abbr guard: {out}"
+        );
     }
 
     #[test]
     fn test_fish_force_unalias_with_abbr() {
         let fish = Fish { use_abbr: true };
         let out = fish.force_unalias("foo");
-        assert!(out.contains("functions -e foo"), "missing functions -e: {out}");
-        assert!(out.contains("abbr --query foo; and abbr --erase foo"), "missing abbr guard: {out}");
+        assert!(
+            out.contains("functions -e foo"),
+            "missing functions -e: {out}"
+        );
+        assert!(
+            out.contains("abbr --query foo; and abbr --erase foo"),
+            "missing abbr guard: {out}"
+        );
     }
 }

--- a/crates/am/src/shell/fish.rs
+++ b/crates/am/src/shell/fish.rs
@@ -120,6 +120,12 @@ impl Shell for Fish {
         }
     }
 
+    fn force_unalias(&self, alias_name: &str) -> String {
+        format!(
+            "functions -e {alias_name}\nabbr --query {alias_name}; and abbr --erase {alias_name}"
+        )
+    }
+
     fn alias(&self, entry: &AliasEntry) -> String {
         if !entry.raw && has_template_args(entry.command) {
             let body = substitute_fish(entry.command);
@@ -420,5 +426,21 @@ mod tests {
     fn test_fish_no_abbr_unalias() {
         let fish = Fish { use_abbr: false };
         assert_eq!(fish.unalias("gs"), "functions -e gs");
+    }
+
+    #[test]
+    fn test_fish_force_unalias_no_abbr() {
+        let fish = Fish { use_abbr: false };
+        let out = fish.force_unalias("foo");
+        assert!(out.contains("functions -e foo"), "missing functions -e: {out}");
+        assert!(out.contains("abbr --query foo; and abbr --erase foo"), "missing abbr guard: {out}");
+    }
+
+    #[test]
+    fn test_fish_force_unalias_with_abbr() {
+        let fish = Fish { use_abbr: true };
+        let out = fish.force_unalias("foo");
+        assert!(out.contains("functions -e foo"), "missing functions -e: {out}");
+        assert!(out.contains("abbr --query foo; and abbr --erase foo"), "missing abbr guard: {out}");
     }
 }

--- a/crates/am/src/shell/mod.rs
+++ b/crates/am/src/shell/mod.rs
@@ -5,6 +5,7 @@ mod nix;
 mod powershell;
 #[allow(clippy::module_inception)]
 mod shell;
+mod shell_enum;
 pub(crate) mod zsh;
 
 pub use brush::*;
@@ -12,6 +13,7 @@ pub use fish::*;
 pub use nix::*;
 pub use powershell::*;
 pub use shell::*;
+pub use shell_enum::Shell;
 
 #[cfg(test)]
 pub(crate) mod test_helpers {

--- a/crates/am/src/shell/nix.rs
+++ b/crates/am/src/shell/nix.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 
-use super::{build_wrapper_trie, has_template_args, quote_cmd, substitute_nix, ShellAdapter, WrapperNode};
+use super::{
+    build_wrapper_trie, has_template_args, quote_cmd, substitute_nix, ShellAdapter, WrapperNode,
+};
 use crate::alias::AliasEntry;
 use crate::subcommand::SubcommandEntry;
 

--- a/crates/am/src/shell/nix.rs
+++ b/crates/am/src/shell/nix.rs
@@ -1,14 +1,14 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 
-use super::{build_wrapper_trie, has_template_args, quote_cmd, substitute_nix, Shell, WrapperNode};
+use super::{build_wrapper_trie, has_template_args, quote_cmd, substitute_nix, ShellAdapter, WrapperNode};
 use crate::alias::AliasEntry;
 use crate::subcommand::SubcommandEntry;
 
 #[derive(Debug, Default)]
 pub struct NixShell;
 
-impl Shell for NixShell {
+impl ShellAdapter for NixShell {
     fn unalias(&self, alias_name: &str) -> String {
         format!("unalias {alias_name} 2>/dev/null; unset -f {alias_name} 2>/dev/null")
     }

--- a/crates/am/src/shell/powershell.rs
+++ b/crates/am/src/shell/powershell.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 
 use super::{
-    build_wrapper_trie, has_template_args, substitute_powershell, substitute_quote_aware, Shell,
+    build_wrapper_trie, has_template_args, substitute_powershell, substitute_quote_aware, ShellAdapter,
     WrapperNode,
 };
 
@@ -23,7 +23,7 @@ use crate::subcommand::SubcommandEntry;
 #[derive(Debug, Default)]
 pub struct PowerShell;
 
-impl Shell for PowerShell {
+impl ShellAdapter for PowerShell {
     fn unalias(&self, alias_name: &str) -> String {
         format!("if (Test-Path Function:\\{alias_name}) {{ Remove-Item Function:\\{alias_name} }}")
     }

--- a/crates/am/src/shell/powershell.rs
+++ b/crates/am/src/shell/powershell.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 use std::fmt::Debug;
 
 use super::{
-    build_wrapper_trie, has_template_args, substitute_powershell, substitute_quote_aware, ShellAdapter,
-    WrapperNode,
+    build_wrapper_trie, has_template_args, substitute_powershell, substitute_quote_aware,
+    ShellAdapter, WrapperNode,
 };
 
 /// Substitute `{{N}}` → `$($args[N-1+offset])` and `{{@}}` → `($args | Select-Object -Skip offset)`.

--- a/crates/am/src/shell/shell.rs
+++ b/crates/am/src/shell/shell.rs
@@ -9,6 +9,14 @@ use crate::config::ShellsTomlConfig;
 
 pub trait Shell: Send + Sync + Debug {
     fn unalias(&self, alias_name: &str) -> String;
+
+    /// Unloads an alias using all possible forms — safe to call regardless of
+    /// which form was used when the alias was originally loaded.
+    /// Default delegates to `unalias`; shells with multiple alias forms override this.
+    fn force_unalias(&self, alias_name: &str) -> String {
+        self.unalias(alias_name)
+    }
+
     fn alias(&self, entry: &crate::alias::AliasEntry) -> String;
     fn set_env(&self, var_name: &str, value: &str) -> String;
     fn unset_env(&self, var_name: &str) -> String;

--- a/crates/am/src/shell/shell.rs
+++ b/crates/am/src/shell/shell.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 
 use crate::config::ShellsTomlConfig;
 
-pub trait Shell: Send + Sync + Debug {
+pub trait ShellAdapter: Send + Sync + Debug {
     fn unalias(&self, alias_name: &str) -> String;
 
     /// Unloads an alias using all possible forms — safe to call regardless of
@@ -33,7 +33,7 @@ pub trait Shell: Send + Sync + Debug {
 }
 
 #[derive(ValueEnum, Clone, Debug, PartialEq)]
-pub enum Shells {
+pub enum Shell {
     Bash,
     Brush,
     // Elvish,
@@ -49,7 +49,7 @@ pub enum Shells {
 }
 
 pub struct ShellContext<'a> {
-    pub shell: &'a Shells,
+    pub shell: &'a Shell,
     pub cfg: &'a ShellsTomlConfig,
     pub cwd: &'a std::path::Path,
     /// Functions already defined in the user's shell — zsh only emits `unset -f` for names here.
@@ -58,42 +58,42 @@ pub struct ShellContext<'a> {
     pub external_aliases: std::collections::HashSet<String>,
 }
 
-impl Shells {
+impl Shell {
     pub fn as_shell(
         self,
         shell_cfg: &ShellsTomlConfig,
         external_functions: std::collections::HashSet<String>,
         external_aliases: std::collections::HashSet<String>,
-    ) -> Box<dyn Shell> {
+    ) -> Box<dyn ShellAdapter> {
         match self {
-            Shells::Fish => Box::new(super::fish::Fish::from_config(shell_cfg.fish.as_ref())),
-            Shells::Zsh => Box::new(super::zsh::Zsh::new(external_functions, external_aliases)),
-            Shells::Bash => Box::new(super::bash::Bash::new(external_functions, external_aliases)),
-            Shells::Brush => Box::from(super::brush::Brush),
-            Shells::Powershell => Box::from(super::powershell::PowerShell),
+            Shell::Fish => Box::new(super::fish::Fish::from_config(shell_cfg.fish.as_ref())),
+            Shell::Zsh => Box::new(super::zsh::Zsh::new(external_functions, external_aliases)),
+            Shell::Bash => Box::new(super::bash::Bash::new(external_functions, external_aliases)),
+            Shell::Brush => Box::from(super::brush::Brush),
+            Shell::Powershell => Box::from(super::powershell::PowerShell),
         }
     }
 }
 
-impl Display for Shells {
+impl Display for Shell {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Shells::Bash => write!(f, "bash"),
-            Shells::Brush => write!(f, "brush"),
-            // Shells::Elvish => write!(f, "elvish"),
-            Shells::Fish => write!(f, "fish"),
-            // Shells::Ksh => write!(f, "ksh"),
-            // Shells::Nushell => write!(f, "nushell"),
-            // Shells::Posix => write!(f, "posix"),
-            Shells::Powershell => write!(f, "powershell"),
-            // Shells::Xonsh => write!(f, "xonsh"),
-            Shells::Zsh => write!(f, "zsh"),
+            Shell::Bash => write!(f, "bash"),
+            Shell::Brush => write!(f, "brush"),
+            // Shell::Elvish => write!(f, "elvish"),
+            Shell::Fish => write!(f, "fish"),
+            // Shell::Ksh => write!(f, "ksh"),
+            // Shell::Nushell => write!(f, "nushell"),
+            // Shell::Posix => write!(f, "posix"),
+            Shell::Powershell => write!(f, "powershell"),
+            // Shell::Xonsh => write!(f, "xonsh"),
+            Shell::Zsh => write!(f, "zsh"),
         }
     }
 }
 
-impl From<Shells> for String {
-    fn from(val: Shells) -> Self {
+impl From<Shell> for String {
+    fn from(val: Shell) -> Self {
         format!("{}", val)
     }
 }
@@ -318,7 +318,7 @@ mod tests {
 
     #[test]
     fn test_bash_shell_generates_nix_syntax() {
-        let shell: Box<dyn Shell> = Shells::Bash.as_shell(
+        let shell: Box<dyn ShellAdapter> = Shell::Bash.as_shell(
             &ShellsTomlConfig::default(),
             Default::default(),
             Default::default(),

--- a/crates/am/src/shell/shell.rs
+++ b/crates/am/src/shell/shell.rs
@@ -2,10 +2,11 @@ use std::collections::BTreeMap;
 use std::fmt::{Debug, Display};
 use std::sync::LazyLock;
 
-use clap::ValueEnum;
 use regex::Regex;
 
 use crate::config::ShellsTomlConfig;
+
+use super::Shell;
 
 pub trait ShellAdapter: Send + Sync + Debug {
     fn unalias(&self, alias_name: &str) -> String;
@@ -30,22 +31,6 @@ pub trait ShellAdapter: Send + Sync + Debug {
         base_cmd: &str,
         entries: &[crate::subcommand::SubcommandEntry],
     ) -> String;
-}
-
-#[derive(ValueEnum, Clone, Debug, PartialEq)]
-pub enum Shell {
-    Bash,
-    Brush,
-    // Elvish,
-    Fish,
-    // Ksh,
-    // Nushell,
-    // Posix,
-    Powershell,
-    // Xonsh,
-    Zsh,
-    // #[cfg(windows)]
-    // Cmd,
 }
 
 pub struct ShellContext<'a> {

--- a/crates/am/src/shell/shell_enum.rs
+++ b/crates/am/src/shell/shell_enum.rs
@@ -1,0 +1,15 @@
+#[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
+pub enum Shell {
+    Bash,
+    Brush,
+    // Elvish,
+    Fish,
+    // Ksh,
+    // Nushell,
+    // Posix,
+    Powershell,
+    // Xonsh,
+    Zsh,
+    // #[cfg(windows)]
+    // Cmd,
+}

--- a/crates/am/src/shell/zsh.rs
+++ b/crates/am/src/shell/zsh.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use super::{has_template_args, quote_cmd, NixShell, Shell};
+use super::{has_template_args, quote_cmd, NixShell, ShellAdapter};
 use crate::alias::AliasEntry;
 
 #[derive(Debug, Default)]
@@ -22,7 +22,7 @@ impl Zsh {
     }
 }
 
-impl Shell for Zsh {
+impl ShellAdapter for Zsh {
     fn unalias(&self, alias_name: &str) -> String {
         NixShell.unalias(alias_name)
     }

--- a/crates/am/src/update.rs
+++ b/crates/am/src/update.rs
@@ -603,6 +603,12 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                     output.push_str(&shell_impl.force_unalias(name));
                     output.push('\n');
                 }
+                // Clear project-alias tracking so __am_hook reloads them fresh
+                // instead of assuming they're still loaded.
+                output.push_str(&shell_impl.unset_env(env_vars::AM_PROJECT_ALIASES));
+                output.push('\n');
+                output.push_str(&shell_impl.unset_env(env_vars::AM_PROJECT_PATH));
+                output.push('\n');
             }
 
             output.push_str(&generate_init(&ctx, &model.config.aliases, &resolved, &all_subs));

--- a/crates/am/src/update.rs
+++ b/crates/am/src/update.rs
@@ -556,7 +556,7 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                 Ok(UpdateResult::done())
             }
         },
-        Message::InitShell(shell) => {
+        Message::InitShell(shell, _force) => {
             let resolved = model
                 .profile_config()
                 .resolve_active_aliases(&model.session.active_profiles);

--- a/crates/am/src/update.rs
+++ b/crates/am/src/update.rs
@@ -556,7 +556,7 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                 Ok(UpdateResult::done())
             }
         },
-        Message::InitShell(shell, _force) => {
+        Message::InitShell(shell, force) => {
             let resolved = model
                 .profile_config()
                 .resolve_active_aliases(&model.session.active_profiles);
@@ -582,7 +582,30 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                 external_functions,
                 external_aliases,
             };
-            let output = generate_init(&ctx, &model.config.aliases, &resolved, &all_subs);
+
+            let mut output = String::new();
+
+            if force {
+                let shell_impl = shell.clone().as_shell(
+                    &model.config.shell,
+                    Default::default(),
+                    Default::default(),
+                );
+                let prev_global = std::env::var(env_vars::AM_ALIASES).unwrap_or_default();
+                let prev_project =
+                    std::env::var(env_vars::AM_PROJECT_ALIASES).unwrap_or_default();
+                let all_prev: Vec<&str> = prev_global
+                    .split(',')
+                    .chain(prev_project.split(','))
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                for name in all_prev {
+                    output.push_str(&shell_impl.force_unalias(name));
+                    output.push('\n');
+                }
+            }
+
+            output.push_str(&generate_init(&ctx, &model.config.aliases, &resolved, &all_subs));
             print!("{output}");
             Ok(UpdateResult::done())
         }

--- a/crates/am/src/update.rs
+++ b/crates/am/src/update.rs
@@ -9,7 +9,7 @@ use crate::project::ProjectAliases;
 use crate::shell::bash;
 use crate::shell::zsh;
 use crate::shell::ShellContext;
-use crate::shell::Shells;
+use crate::shell::Shell;
 use crate::trust::ProjectTrust;
 use crate::{profile, AliasDisplayFilter, AliasTarget, Message, Profile};
 
@@ -568,8 +568,8 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                 all_subs.insert(k, v);
             }
             let (external_functions, external_aliases) = match shell {
-                Shells::Zsh => (zsh::scan_external_functions(), zsh::scan_external_aliases()),
-                Shells::Bash => (
+                Shell::Zsh => (zsh::scan_external_functions(), zsh::scan_external_aliases()),
+                Shell::Bash => (
                     bash::scan_external_functions(),
                     bash::scan_external_aliases(),
                 ),

--- a/crates/am/src/update.rs
+++ b/crates/am/src/update.rs
@@ -8,8 +8,8 @@ use crate::profile::AliasCollection;
 use crate::project::ProjectAliases;
 use crate::shell::bash;
 use crate::shell::zsh;
-use crate::shell::ShellContext;
 use crate::shell::Shell;
+use crate::shell::ShellContext;
 use crate::trust::ProjectTrust;
 use crate::{profile, AliasDisplayFilter, AliasTarget, Message, Profile};
 
@@ -592,8 +592,7 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                     Default::default(),
                 );
                 let prev_global = std::env::var(env_vars::AM_ALIASES).unwrap_or_default();
-                let prev_project =
-                    std::env::var(env_vars::AM_PROJECT_ALIASES).unwrap_or_default();
+                let prev_project = std::env::var(env_vars::AM_PROJECT_ALIASES).unwrap_or_default();
                 let all_prev: Vec<&str> = prev_global
                     .split(',')
                     .chain(prev_project.split(','))
@@ -611,7 +610,12 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                 output.push('\n');
             }
 
-            output.push_str(&generate_init(&ctx, &model.config.aliases, &resolved, &all_subs));
+            output.push_str(&generate_init(
+                &ctx,
+                &model.config.aliases,
+                &resolved,
+                &all_subs,
+            ));
             print!("{output}");
             Ok(UpdateResult::done())
         }

--- a/crates/am/tests/snapshots.rs
+++ b/crates/am/tests/snapshots.rs
@@ -1,11 +1,11 @@
 use amoxide::alias::{AliasConflict, MergeResult};
-use amoxide::config::ShellsTomlConfig;
+use amoxide::config::{FishConfig, ShellsTomlConfig};
 use amoxide::display::{render_listing, render_profiles};
 use amoxide::exchange::{
     render_import_summary, render_suspicious_warning, ExportAll, SuspiciousAlias,
 };
 use amoxide::hook::generate_hook_with_security;
-use amoxide::init::{generate_init, generate_reload};
+use amoxide::init::{generate_force_init, generate_init, generate_reload};
 use amoxide::project::ProjectAliases;
 use amoxide::security::SecurityConfig;
 use amoxide::shell::{ShellContext, Shells};
@@ -1040,5 +1040,76 @@ fn snapshot_share_help() {
         paste_rs: false,
     };
     let output = handle_share(&args);
+    insta::assert_snapshot!(output);
+}
+
+fn abbr_ctx(shell: &Shells) -> ShellContext<'_> {
+    static ABBR_CFG: std::sync::LazyLock<ShellsTomlConfig> =
+        std::sync::LazyLock::new(|| ShellsTomlConfig {
+            fish: Some(FishConfig { use_abbr: true }),
+            ..Default::default()
+        });
+    ShellContext {
+        shell,
+        cfg: &ABBR_CFG,
+        cwd: std::path::Path::new("/tmp"),
+        external_functions: Default::default(),
+        external_aliases: Default::default(),
+    }
+}
+
+#[test]
+fn snapshot_init_fish_force_with_tracked_aliases() {
+    // Simulates: _AM_ALIASES=gs,ll is set, user runs am init --force fish.
+    // force_unalias must emit both cleanup forms for each tracked name,
+    // followed by the normal init output.
+    let prev_names = vec!["gs".to_string(), "ll".to_string()];
+    let output = generate_force_init(
+        &default_ctx(&Shells::Fish),
+        &aliases(&[("gs", "git status"), ("ll", "ls -lha")]),
+        &AliasSet::default(),
+        &SubcommandSet::new(),
+        &prev_names,
+    );
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn snapshot_init_fish_abbr_force_with_tracked_aliases() {
+    // Same but with use_abbr = true — cleanup must still emit both forms.
+    let prev_names = vec!["gs".to_string()];
+    let output = generate_force_init(
+        &abbr_ctx(&Shells::Fish),
+        &aliases(&[("gs", "git status")]),
+        &AliasSet::default(),
+        &SubcommandSet::new(),
+        &prev_names,
+    );
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn snapshot_init_fish_force_no_previous() {
+    // --force with no tracked aliases: no cleanup lines, just normal init.
+    let output = generate_force_init(
+        &default_ctx(&Shells::Fish),
+        &aliases(&[("gs", "git status")]),
+        &AliasSet::default(),
+        &SubcommandSet::new(),
+        &[],
+    );
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn snapshot_init_bash_force_with_tracked_aliases() {
+    let prev_names = vec!["gs".to_string()];
+    let output = generate_force_init(
+        &default_ctx(&Shells::Bash),
+        &aliases(&[("gs", "git status")]),
+        &AliasSet::default(),
+        &SubcommandSet::new(),
+        &prev_names,
+    );
     insta::assert_snapshot!(output);
 }

--- a/crates/am/tests/snapshots.rs
+++ b/crates/am/tests/snapshots.rs
@@ -8,7 +8,7 @@ use amoxide::hook::generate_hook_with_security;
 use amoxide::init::{generate_force_init, generate_init, generate_reload};
 use amoxide::project::ProjectAliases;
 use amoxide::security::SecurityConfig;
-use amoxide::shell::{ShellContext, Shell};
+use amoxide::shell::{Shell, ShellContext};
 use amoxide::subcommand::SubcommandSet;
 use amoxide::trust::compute_file_hash;
 use amoxide::{AliasName, AliasSet, ProfileConfig, TomlAlias};

--- a/crates/am/tests/snapshots.rs
+++ b/crates/am/tests/snapshots.rs
@@ -1047,7 +1047,6 @@ fn abbr_ctx(shell: &Shells) -> ShellContext<'_> {
     static ABBR_CFG: std::sync::LazyLock<ShellsTomlConfig> =
         std::sync::LazyLock::new(|| ShellsTomlConfig {
             fish: Some(FishConfig { use_abbr: true }),
-            ..Default::default()
         });
     ShellContext {
         shell,

--- a/crates/am/tests/snapshots.rs
+++ b/crates/am/tests/snapshots.rs
@@ -8,7 +8,7 @@ use amoxide::hook::generate_hook_with_security;
 use amoxide::init::{generate_force_init, generate_init, generate_reload};
 use amoxide::project::ProjectAliases;
 use amoxide::security::SecurityConfig;
-use amoxide::shell::{ShellContext, Shells};
+use amoxide::shell::{ShellContext, Shell};
 use amoxide::subcommand::SubcommandSet;
 use amoxide::trust::compute_file_hash;
 use amoxide::{AliasName, AliasSet, ProfileConfig, TomlAlias};
@@ -16,7 +16,7 @@ use amoxide::{AliasName, AliasSet, ProfileConfig, TomlAlias};
 static DEFAULT_CFG: std::sync::LazyLock<ShellsTomlConfig> =
     std::sync::LazyLock::new(ShellsTomlConfig::default);
 
-fn default_ctx(shell: &Shells) -> ShellContext<'_> {
+fn default_ctx(shell: &Shell) -> ShellContext<'_> {
     ShellContext {
         shell,
         cfg: &DEFAULT_CFG,
@@ -98,7 +98,7 @@ fn snapshot_init_fish_simple_profile() {
     "#});
     let resolved = config.resolve_active_aliases(&["default"]);
     let output = generate_init(
-        &default_ctx(&Shells::Fish),
+        &default_ctx(&Shell::Fish),
         &AliasSet::default(),
         &resolved,
         &SubcommandSet::new(),
@@ -117,7 +117,7 @@ fn snapshot_init_zsh_simple_profile() {
     "#});
     let resolved = config.resolve_active_aliases(&["default"]);
     let output = generate_init(
-        &default_ctx(&Shells::Zsh),
+        &default_ctx(&Shell::Zsh),
         &AliasSet::default(),
         &resolved,
         &SubcommandSet::new(),
@@ -136,7 +136,7 @@ fn snapshot_init_powershell_simple_profile() {
     "#});
     let resolved = config.resolve_active_aliases(&["default"]);
     let output = generate_init(
-        &default_ctx(&Shells::Powershell),
+        &default_ctx(&Shell::Powershell),
         &AliasSet::default(),
         &resolved,
         &SubcommandSet::new(),
@@ -155,7 +155,7 @@ fn snapshot_init_bash_simple_profile() {
     "#});
     let resolved = config.resolve_active_aliases(&["default"]);
     let output = generate_init(
-        &default_ctx(&Shells::Bash),
+        &default_ctx(&Shell::Bash),
         &AliasSet::default(),
         &resolved,
         &SubcommandSet::new(),
@@ -168,7 +168,7 @@ fn snapshot_init_fish_multi_profile() {
     let config = git_conventional_config();
     let resolved = config.resolve_active_aliases(&["git", "git-conventional"]);
     let output = generate_init(
-        &default_ctx(&Shells::Fish),
+        &default_ctx(&Shell::Fish),
         &AliasSet::default(),
         &resolved,
         &SubcommandSet::new(),
@@ -187,7 +187,7 @@ fn snapshot_init_fish_with_globals() {
     let globals = aliases(&[("ll", "ls -lha")]);
     let resolved = config.resolve_active_aliases(&["rust"]);
     let output = generate_init(
-        &default_ctx(&Shells::Fish),
+        &default_ctx(&Shell::Fish),
         &globals,
         &resolved,
         &SubcommandSet::new(),
@@ -200,7 +200,7 @@ fn snapshot_init_fish_deep_chain() {
     let config = deep_chain_config();
     let resolved = config.resolve_active_aliases(&["base", "git", "rust"]);
     let output = generate_init(
-        &default_ctx(&Shells::Fish),
+        &default_ctx(&Shell::Fish),
         &AliasSet::default(),
         &resolved,
         &SubcommandSet::new(),
@@ -215,7 +215,7 @@ fn snapshot_init_fish_with_simple_subcommands() {
     subcommands.insert("jj:ab".into(), vec!["abandon".into()]);
     subcommands.insert("jj:new".into(), vec!["new --no-edit".into()]);
     let output = generate_init(
-        &default_ctx(&Shells::Fish),
+        &default_ctx(&Shell::Fish),
         &globals,
         &AliasSet::default(),
         &subcommands,
@@ -238,7 +238,7 @@ fn snapshot_init_bash_with_kubectl_subcommands() {
     );
     subcommands.insert("kubectl:logs:f".into(), vec!["logs".into(), "-f".into()]);
     let output = generate_init(
-        &default_ctx(&Shells::Bash),
+        &default_ctx(&Shell::Bash),
         &AliasSet::default(),
         &AliasSet::default(),
         &subcommands,
@@ -255,7 +255,7 @@ fn snapshot_reload_fish_switch_profile() {
     let config = git_conventional_config();
     let resolved = config.resolve_active_aliases(&["git", "git-conventional"]);
     let output = generate_reload(
-        &default_ctx(&Shells::Fish),
+        &default_ctx(&Shell::Fish),
         &AliasSet::default(),
         &resolved,
         &SubcommandSet::new(),
@@ -269,7 +269,7 @@ fn snapshot_reload_zsh_switch_profile() {
     let config = git_conventional_config();
     let resolved = config.resolve_active_aliases(&["git", "git-conventional"]);
     let output = generate_reload(
-        &default_ctx(&Shells::Zsh),
+        &default_ctx(&Shell::Zsh),
         &AliasSet::default(),
         &resolved,
         &SubcommandSet::new(),
@@ -283,7 +283,7 @@ fn snapshot_reload_powershell_switch_profile() {
     let config = git_conventional_config();
     let resolved = config.resolve_active_aliases(&["git-conventional"]);
     let output = generate_reload(
-        &default_ctx(&Shells::Powershell),
+        &default_ctx(&Shell::Powershell),
         &AliasSet::default(),
         &resolved,
         &SubcommandSet::new(),
@@ -297,7 +297,7 @@ fn snapshot_reload_bash_switch_profile() {
     let config = git_conventional_config();
     let resolved = config.resolve_active_aliases(&["git", "git-conventional"]);
     let output = generate_reload(
-        &default_ctx(&Shells::Bash),
+        &default_ctx(&Shell::Bash),
         &AliasSet::default(),
         &resolved,
         &SubcommandSet::new(),
@@ -313,7 +313,7 @@ fn snapshot_reload_fish_after_global_add() {
     let config = git_conventional_config();
     let resolved = config.resolve_active_aliases(&["git", "git-conventional"]);
     let output = generate_reload(
-        &default_ctx(&Shells::Fish),
+        &default_ctx(&Shell::Fish),
         &globals,
         &resolved,
         &SubcommandSet::new(),
@@ -327,7 +327,7 @@ fn snapshot_reload_fish_globals_only_no_profile() {
     // No active profile, only globals
     let globals = aliases(&[("ll", "ls -lha"), ("gs", "git status")]);
     let output = generate_reload(
-        &default_ctx(&Shells::Fish),
+        &default_ctx(&Shell::Fish),
         &globals,
         &AliasSet::default(),
         &SubcommandSet::new(),
@@ -342,7 +342,7 @@ fn snapshot_reload_zsh_after_global_add() {
     let config = git_conventional_config();
     let resolved = config.resolve_active_aliases(&["git", "git-conventional"]);
     let output = generate_reload(
-        &default_ctx(&Shells::Zsh),
+        &default_ctx(&Shell::Zsh),
         &globals,
         &resolved,
         &SubcommandSet::new(),
@@ -357,7 +357,7 @@ fn snapshot_reload_bash_after_global_add() {
     let config = git_conventional_config();
     let resolved = config.resolve_active_aliases(&["git", "git-conventional"]);
     let output = generate_reload(
-        &default_ctx(&Shells::Bash),
+        &default_ctx(&Shell::Bash),
         &globals,
         &resolved,
         &SubcommandSet::new(),
@@ -373,7 +373,7 @@ fn snapshot_init_fish_globals_and_multi_profile() {
     let config = git_conventional_config();
     let resolved = config.resolve_active_aliases(&["git", "git-conventional"]);
     let output = generate_init(
-        &default_ctx(&Shells::Fish),
+        &default_ctx(&Shell::Fish),
         &globals,
         &resolved,
         &SubcommandSet::new(),
@@ -401,7 +401,7 @@ fn snapshot_reload_after_profile_removed() {
     let resolved = config.resolve_active_aliases(&["git"]);
     // Previously tracked: cm,ct,gs (git's + rust's aliases were all loaded)
     let output = generate_reload(
-        &default_ctx(&Shells::Fish),
+        &default_ctx(&Shell::Fish),
         &AliasSet::default(),
         &resolved,
         &SubcommandSet::new(),
@@ -423,7 +423,7 @@ fn snapshot_reload_after_parent_profile_removed() {
     let resolved = config.resolve_active_aliases(&["git-conventional"]);
     // Previously tracked: cm,cmf,gs (git's + git-conventional's were loaded)
     let output = generate_reload(
-        &default_ctx(&Shells::Fish),
+        &default_ctx(&Shell::Fish),
         &AliasSet::default(),
         &resolved,
         &SubcommandSet::new(),
@@ -455,7 +455,7 @@ fn snapshot_reload_after_active_set_changed() {
     // Previously tracked: ct,gs (from rust + git)
     // Now should have: ct,ll (from rust + base)
     let output = generate_reload(
-        &default_ctx(&Shells::Fish),
+        &default_ctx(&Shell::Fish),
         &AliasSet::default(),
         &resolved,
         &SubcommandSet::new(),
@@ -487,7 +487,7 @@ fn snapshot_hook_fish_with_aliases() {
     security.trust(&aliases_path, &hash);
 
     let ctx = ShellContext {
-        shell: &Shells::Fish,
+        shell: &Shell::Fish,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
         external_functions: Default::default(),
@@ -516,7 +516,7 @@ fn snapshot_hook_zsh_with_aliases() {
     security.trust(&aliases_path, &hash);
 
     let ctx = ShellContext {
-        shell: &Shells::Zsh,
+        shell: &Shell::Zsh,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
         external_functions: Default::default(),
@@ -545,7 +545,7 @@ fn snapshot_hook_powershell_with_aliases() {
     security.trust(&aliases_path, &hash);
 
     let ctx = ShellContext {
-        shell: &Shells::Powershell,
+        shell: &Shell::Powershell,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
         external_functions: Default::default(),
@@ -574,7 +574,7 @@ fn snapshot_hook_bash_with_aliases() {
     security.trust(&aliases_path, &hash);
 
     let ctx = ShellContext {
-        shell: &Shells::Bash,
+        shell: &Shell::Bash,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
         external_functions: Default::default(),
@@ -602,7 +602,7 @@ fn snapshot_hook_fish_transition() {
     security.trust(&aliases_path, &hash);
 
     let ctx = ShellContext {
-        shell: &Shells::Fish,
+        shell: &Shell::Fish,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
         external_functions: Default::default(),
@@ -619,7 +619,7 @@ fn snapshot_hook_fish_leaving_project() {
     // No .aliases file
     let mut security = SecurityConfig::default();
     let ctx = ShellContext {
-        shell: &Shells::Fish,
+        shell: &Shell::Fish,
         cfg: &DEFAULT_CFG,
         cwd: dir.path(),
         external_functions: Default::default(),
@@ -1043,7 +1043,7 @@ fn snapshot_share_help() {
     insta::assert_snapshot!(output);
 }
 
-fn abbr_ctx(shell: &Shells) -> ShellContext<'_> {
+fn abbr_ctx(shell: &Shell) -> ShellContext<'_> {
     static ABBR_CFG: std::sync::LazyLock<ShellsTomlConfig> =
         std::sync::LazyLock::new(|| ShellsTomlConfig {
             fish: Some(FishConfig { use_abbr: true }),
@@ -1064,7 +1064,7 @@ fn snapshot_init_fish_force_with_tracked_aliases() {
     // followed by the normal init output.
     let prev_names = vec!["gs".to_string(), "ll".to_string()];
     let output = generate_force_init(
-        &default_ctx(&Shells::Fish),
+        &default_ctx(&Shell::Fish),
         &aliases(&[("gs", "git status"), ("ll", "ls -lha")]),
         &AliasSet::default(),
         &SubcommandSet::new(),
@@ -1078,7 +1078,7 @@ fn snapshot_init_fish_abbr_force_with_tracked_aliases() {
     // Same but with use_abbr = true — cleanup must still emit both forms.
     let prev_names = vec!["gs".to_string()];
     let output = generate_force_init(
-        &abbr_ctx(&Shells::Fish),
+        &abbr_ctx(&Shell::Fish),
         &aliases(&[("gs", "git status")]),
         &AliasSet::default(),
         &SubcommandSet::new(),
@@ -1091,7 +1091,7 @@ fn snapshot_init_fish_abbr_force_with_tracked_aliases() {
 fn snapshot_init_fish_force_no_previous() {
     // --force with no tracked aliases: no cleanup lines, just normal init.
     let output = generate_force_init(
-        &default_ctx(&Shells::Fish),
+        &default_ctx(&Shell::Fish),
         &aliases(&[("gs", "git status")]),
         &AliasSet::default(),
         &SubcommandSet::new(),
@@ -1104,7 +1104,7 @@ fn snapshot_init_fish_force_no_previous() {
 fn snapshot_init_bash_force_with_tracked_aliases() {
     let prev_names = vec!["gs".to_string()];
     let output = generate_force_init(
-        &default_ctx(&Shells::Bash),
+        &default_ctx(&Shell::Bash),
         &aliases(&[("gs", "git status")]),
         &AliasSet::default(),
         &SubcommandSet::new(),

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_bash_force_with_tracked_aliases.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_bash_force_with_tracked_aliases.snap
@@ -596,7 +596,7 @@ _am() {
             return 0
             ;;
         am__subcmd__hook)
-            opts="-q -h -V --quiet --help --version bash fish powershell zsh"
+            opts="-q -h -V --quiet --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -632,7 +632,7 @@ _am() {
             return 0
             ;;
         am__subcmd__init)
-            opts="-f -h -V --force --help --version bash fish powershell zsh"
+            opts="-f -h -V --force --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -822,7 +822,7 @@ _am() {
             return 0
             ;;
         am__subcmd__reload)
-            opts="-h -V --help --version bash fish powershell zsh"
+            opts="-h -V --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -862,7 +862,7 @@ _am() {
             return 0
             ;;
         am__subcmd__setup)
-            opts="-h -V --help --version bash fish powershell zsh"
+            opts="-h -V --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_bash_force_with_tracked_aliases.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_bash_force_with_tracked_aliases.snap
@@ -3,6 +3,8 @@ source: crates/am/tests/snapshots.rs
 expression: output
 ---
 unalias gs 2>/dev/null; unset -f gs 2>/dev/null
+unset _AM_PROJECT_ALIASES
+unset _AM_PROJECT_PATH
 alias gs="git status"
 export _AM_ALIASES="gs"
 unset _AM_PROFILE_ALIASES

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_bash_force_with_tracked_aliases.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_bash_force_with_tracked_aliases.snap
@@ -1,0 +1,983 @@
+---
+source: crates/am/tests/snapshots.rs
+expression: output
+---
+unalias gs 2>/dev/null; unset -f gs 2>/dev/null
+alias gs="git status"
+export _AM_ALIASES="gs"
+unset _AM_PROFILE_ALIASES
+
+am() {
+  command am "$@"
+  local am_status=$?
+  if [[ $am_status -ne 0 ]]; then return $am_status; fi
+  case "$1" in
+    tui|t) eval "$(command am reload bash)"; eval "$(command am hook bash)"; return ;;
+  esac
+  case "$1" in
+    use|u) eval "$(command am reload bash)"; return ;;
+  esac
+  case "$1:$2" in
+    profile:use|p:use|profile:u|p:u|profile:add|p:add|profile:a|p:a|profile:remove|p:remove|profile:r|p:r) eval "$(command am reload bash)" ;;
+  esac
+  case "$1" in
+    add|a|remove|r)
+      case "$*" in
+        *\ -l\ *|*\ --local\ *|*\ -l|*\ --local) eval "$(command am hook bash)" ;;
+        *) eval "$(command am reload bash)" ;;
+      esac ;;
+    trust) eval "$(command am hook bash)" ;;
+    untrust) eval "$(command am hook --quiet bash)" ;;
+  esac
+}
+
+
+# am cd hook: track directory changes and reload project aliases
+__am_hook() {
+  local previous_exit_status=$?
+  if [[ "${__am_prev_dir:-}" != "$PWD" ]]; then
+    __am_prev_dir="$PWD"
+    eval "$(command am hook bash)"
+  fi
+  return $previous_exit_status
+}
+if [[ "$(declare -p PROMPT_COMMAND 2>&1)" == "declare -a"* ]]; then
+  case " ${PROMPT_COMMAND[*]} " in
+    *" __am_hook "*) ;;
+    *) PROMPT_COMMAND=(__am_hook "${PROMPT_COMMAND[@]}") ;;
+  esac
+else
+  case ";${PROMPT_COMMAND:-};" in
+    *";__am_hook;"*) ;;
+    *) PROMPT_COMMAND="__am_hook${PROMPT_COMMAND:+;$PROMPT_COMMAND}" ;;
+  esac
+fi
+__am_hook
+
+
+_am() {
+    local i cur prev opts cmd
+    COMPREPLY=()
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
+    cmd=""
+    opts=""
+
+    for i in "${COMP_WORDS[@]:0:COMP_CWORD}"
+    do
+        case "${cmd},${i}" in
+            ",$1")
+                cmd="am"
+                ;;
+            am,add)
+                cmd="am__subcmd__add"
+                ;;
+            am,export)
+                cmd="am__subcmd__export"
+                ;;
+            am,help)
+                cmd="am__subcmd__help"
+                ;;
+            am,hook)
+                cmd="am__subcmd__hook"
+                ;;
+            am,import)
+                cmd="am__subcmd__import"
+                ;;
+            am,init)
+                cmd="am__subcmd__init"
+                ;;
+            am,ls)
+                cmd="am__subcmd__ls"
+                ;;
+            am,profile)
+                cmd="am__subcmd__profile"
+                ;;
+            am,reload)
+                cmd="am__subcmd__reload"
+                ;;
+            am,remove)
+                cmd="am__subcmd__remove"
+                ;;
+            am,setup)
+                cmd="am__subcmd__setup"
+                ;;
+            am,share)
+                cmd="am__subcmd__share"
+                ;;
+            am,status)
+                cmd="am__subcmd__status"
+                ;;
+            am,trust)
+                cmd="am__subcmd__trust"
+                ;;
+            am,tui)
+                cmd="am__subcmd__tui"
+                ;;
+            am,untrust)
+                cmd="am__subcmd__untrust"
+                ;;
+            am,use)
+                cmd="am__subcmd__use"
+                ;;
+            am__subcmd__help,add)
+                cmd="am__subcmd__help__subcmd__add"
+                ;;
+            am__subcmd__help,export)
+                cmd="am__subcmd__help__subcmd__export"
+                ;;
+            am__subcmd__help,help)
+                cmd="am__subcmd__help__subcmd__help"
+                ;;
+            am__subcmd__help,hook)
+                cmd="am__subcmd__help__subcmd__hook"
+                ;;
+            am__subcmd__help,import)
+                cmd="am__subcmd__help__subcmd__import"
+                ;;
+            am__subcmd__help,init)
+                cmd="am__subcmd__help__subcmd__init"
+                ;;
+            am__subcmd__help,ls)
+                cmd="am__subcmd__help__subcmd__ls"
+                ;;
+            am__subcmd__help,profile)
+                cmd="am__subcmd__help__subcmd__profile"
+                ;;
+            am__subcmd__help,reload)
+                cmd="am__subcmd__help__subcmd__reload"
+                ;;
+            am__subcmd__help,remove)
+                cmd="am__subcmd__help__subcmd__remove"
+                ;;
+            am__subcmd__help,setup)
+                cmd="am__subcmd__help__subcmd__setup"
+                ;;
+            am__subcmd__help,share)
+                cmd="am__subcmd__help__subcmd__share"
+                ;;
+            am__subcmd__help,status)
+                cmd="am__subcmd__help__subcmd__status"
+                ;;
+            am__subcmd__help,trust)
+                cmd="am__subcmd__help__subcmd__trust"
+                ;;
+            am__subcmd__help,tui)
+                cmd="am__subcmd__help__subcmd__tui"
+                ;;
+            am__subcmd__help,untrust)
+                cmd="am__subcmd__help__subcmd__untrust"
+                ;;
+            am__subcmd__help,use)
+                cmd="am__subcmd__help__subcmd__use"
+                ;;
+            am__subcmd__help__subcmd__profile,add)
+                cmd="am__subcmd__help__subcmd__profile__subcmd__add"
+                ;;
+            am__subcmd__help__subcmd__profile,list)
+                cmd="am__subcmd__help__subcmd__profile__subcmd__list"
+                ;;
+            am__subcmd__help__subcmd__profile,remove)
+                cmd="am__subcmd__help__subcmd__profile__subcmd__remove"
+                ;;
+            am__subcmd__help__subcmd__profile,use)
+                cmd="am__subcmd__help__subcmd__profile__subcmd__use"
+                ;;
+            am__subcmd__profile,add)
+                cmd="am__subcmd__profile__subcmd__add"
+                ;;
+            am__subcmd__profile,help)
+                cmd="am__subcmd__profile__subcmd__help"
+                ;;
+            am__subcmd__profile,list)
+                cmd="am__subcmd__profile__subcmd__list"
+                ;;
+            am__subcmd__profile,remove)
+                cmd="am__subcmd__profile__subcmd__remove"
+                ;;
+            am__subcmd__profile,use)
+                cmd="am__subcmd__profile__subcmd__use"
+                ;;
+            am__subcmd__profile__subcmd__help,add)
+                cmd="am__subcmd__profile__subcmd__help__subcmd__add"
+                ;;
+            am__subcmd__profile__subcmd__help,help)
+                cmd="am__subcmd__profile__subcmd__help__subcmd__help"
+                ;;
+            am__subcmd__profile__subcmd__help,list)
+                cmd="am__subcmd__profile__subcmd__help__subcmd__list"
+                ;;
+            am__subcmd__profile__subcmd__help,remove)
+                cmd="am__subcmd__profile__subcmd__help__subcmd__remove"
+                ;;
+            am__subcmd__profile__subcmd__help,use)
+                cmd="am__subcmd__profile__subcmd__help__subcmd__use"
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    case "${cmd}" in
+        am)
+            opts="-h -V --help --version add remove ls status profile init setup use tui export import share trust untrust hook reload help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__add)
+            opts="-p -l -g -h -V --profile --local --global --raw --sub --help --version <NAME> [COMMAND]..."
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --profile)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --sub)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__export)
+            opts="-l -g -p -b -h -V --local --global --profile --all --base64 --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --profile)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help)
+            opts="add remove ls status profile init setup use tui export import share trust untrust hook reload help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__export)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__hook)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__import)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__init)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__ls)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__profile)
+            opts="add use remove list"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__profile__subcmd__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__profile__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__profile__subcmd__remove)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__profile__subcmd__use)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__reload)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__remove)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__setup)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__share)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__status)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__trust)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__tui)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__untrust)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__help__subcmd__use)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__hook)
+            opts="-q -h -V --quiet --help --version bash fish powershell zsh"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__import)
+            opts="-l -g -p -b -y -h -V --local --global --profile --all --base64 --yes --trust --help --version <SOURCE>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --profile)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__init)
+            opts="-f -h -V --force --help --version bash fish powershell zsh"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__ls)
+            opts="-u -h -V --used --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__profile)
+            opts="-h -V --help --version add use remove list help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__profile__subcmd__add)
+            opts="-h -V --help --version <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__profile__subcmd__help)
+            opts="add use remove list help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__profile__subcmd__help__subcmd__add)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__profile__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__profile__subcmd__help__subcmd__list)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__profile__subcmd__help__subcmd__remove)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__profile__subcmd__help__subcmd__use)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__profile__subcmd__list)
+            opts="-u -h -V --used --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__profile__subcmd__remove)
+            opts="-f -h -V --force --help --version <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__profile__subcmd__use)
+            opts="-n -i -h -V --priority --inverse --help --version [NAMES]..."
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --priority)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -n)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__reload)
+            opts="-h -V --help --version bash fish powershell zsh"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__remove)
+            opts="-p -l -g -h -V --profile --local --global --sub --help --version <NAME>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --profile)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --sub)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__setup)
+            opts="-h -V --help --version bash fish powershell zsh"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__share)
+            opts="-l -g -p -h -V --local --global --profile --all --termbin --paste-rs --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --profile)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__status)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__trust)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__tui)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__untrust)
+            opts="-f -h -V --forget --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        am__subcmd__use)
+            opts="-n -i -h -V --priority --inverse --help --version [NAMES]..."
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --priority)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -n)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+    esac
+}
+
+if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
+    complete -F _am -o nosort -o bashdefault -o default am
+else
+    complete -F _am -o bashdefault -o default am
+fi

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_bash_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_bash_simple_profile.snap
@@ -594,7 +594,7 @@ _am() {
             return 0
             ;;
         am__subcmd__hook)
-            opts="-q -h -V --quiet --help --version bash fish powershell zsh"
+            opts="-q -h -V --quiet --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -630,7 +630,7 @@ _am() {
             return 0
             ;;
         am__subcmd__init)
-            opts="-f -h -V --force --help --version bash fish powershell zsh"
+            opts="-f -h -V --force --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -820,7 +820,7 @@ _am() {
             return 0
             ;;
         am__subcmd__reload)
-            opts="-h -V --help --version bash fish powershell zsh"
+            opts="-h -V --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -860,7 +860,7 @@ _am() {
             return 0
             ;;
         am__subcmd__setup)
-            opts="-h -V --help --version bash fish powershell zsh"
+            opts="-h -V --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_bash_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_bash_simple_profile.snap
@@ -630,7 +630,7 @@ _am() {
             return 0
             ;;
         am__subcmd__init)
-            opts="-h -V --help --version bash fish powershell zsh"
+            opts="-f -h -V --force --help --version bash fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_bash_with_kubectl_subcommands.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_bash_with_kubectl_subcommands.snap
@@ -622,7 +622,7 @@ _am() {
             return 0
             ;;
         am__subcmd__hook)
-            opts="-q -h -V --quiet --help --version bash fish powershell zsh"
+            opts="-q -h -V --quiet --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -658,7 +658,7 @@ _am() {
             return 0
             ;;
         am__subcmd__init)
-            opts="-f -h -V --force --help --version bash fish powershell zsh"
+            opts="-f -h -V --force --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -848,7 +848,7 @@ _am() {
             return 0
             ;;
         am__subcmd__reload)
-            opts="-h -V --help --version bash fish powershell zsh"
+            opts="-h -V --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -888,7 +888,7 @@ _am() {
             return 0
             ;;
         am__subcmd__setup)
-            opts="-h -V --help --version bash fish powershell zsh"
+            opts="-h -V --help --version bash brush fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_bash_with_kubectl_subcommands.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_bash_with_kubectl_subcommands.snap
@@ -658,7 +658,7 @@ _am() {
             return 0
             ;;
         am__subcmd__init)
-            opts="-h -V --help --version bash fish powershell zsh"
+            opts="-f -h -V --force --help --version bash fish powershell zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_abbr_force_with_tracked_aliases.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_abbr_force_with_tracked_aliases.snap
@@ -4,6 +4,8 @@ expression: output
 ---
 functions -e gs
 abbr --query gs; and abbr --erase gs
+set -e _AM_PROJECT_ALIASES
+set -e _AM_PROJECT_PATH
 abbr --add gs "git status"
 set -gx _AM_ALIASES "gs"
 set -e _AM_PROFILE_ALIASES

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_abbr_force_with_tracked_aliases.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_abbr_force_with_tracked_aliases.snap
@@ -1,0 +1,207 @@
+---
+source: crates/am/tests/snapshots.rs
+expression: output
+---
+functions -e gs
+abbr --query gs; and abbr --erase gs
+abbr --add gs "git status"
+set -gx _AM_ALIASES "gs"
+set -e _AM_PROFILE_ALIASES
+
+# am wrapper: reload aliases after mutations
+function am --wraps=am
+    command am $argv
+    set -l am_status $status
+    if test $am_status -ne 0
+        return $am_status
+    end
+    # tui may have changed anything → always reload after
+    if begin; test "$argv[1]" = tui; or test "$argv[1]" = t; end
+        command am reload fish | source
+        command am hook fish | source
+        return
+    end
+    # top-level use → reload aliases
+    if begin; test "$argv[1]" = use; or test "$argv[1]" = u; end
+        command am reload fish | source
+        return
+    end
+    # profile mutation → reload aliases
+    if begin; test "$argv[1]" = profile; or test "$argv[1]" = p; end
+        if begin; test "$argv[2]" = use; or test "$argv[2]" = u; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
+            command am reload fish | source
+        end
+    else if begin; test "$argv[1]" = add; or test "$argv[1]" = a; or test "$argv[1]" = remove; or test "$argv[1]" = r; end
+        if contains -- -l $argv; or contains -- --local $argv
+            # local alias change → reload project aliases
+            command am hook fish | source
+        else
+            # profile/global alias change → reload
+            command am reload fish | source
+        end
+    else if test "$argv[1]" = trust
+        command am hook fish | source
+    else if test "$argv[1]" = untrust
+        command am hook --quiet fish | source
+    end
+end
+
+# am cd hook
+function __am_hook --on-variable PWD
+    am hook fish | source
+end
+__am_hook
+
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_am_global_optspecs
+	string join \n h/help V/version
+end
+
+function __fish_am_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_am_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_am_using_subcommand
+	set -l cmd (__fish_am_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c am -n "__fish_am_needs_command" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_needs_command" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_needs_command" -f -a "add" -d 'Add a new alias'
+complete -c am -n "__fish_am_needs_command" -f -a "remove" -d 'Remove an alias'
+complete -c am -n "__fish_am_needs_command" -f -a "ls" -d 'List all profiles and project aliases'
+complete -c am -n "__fish_am_needs_command" -f -a "status" -d 'Check if the shell is set up correctly'
+complete -c am -n "__fish_am_needs_command" -f -a "profile" -d 'Manage profiles (defaults to listing when no subcommand given)'
+complete -c am -n "__fish_am_needs_command" -f -a "init" -d 'Print shell init code'
+complete -c am -n "__fish_am_needs_command" -f -a "setup" -d 'Guided setup — adds amoxide to your shell profile'
+complete -c am -n "__fish_am_needs_command" -f -a "use" -d 'Shortcut for `am profile use` — toggle one or more profiles'
+complete -c am -n "__fish_am_needs_command" -f -a "tui" -d 'Launch the interactive TUI for managing aliases and profiles'
+complete -c am -n "__fish_am_needs_command" -f -a "export" -d 'Export aliases to stdout as TOML'
+complete -c am -n "__fish_am_needs_command" -f -a "import" -d 'Import aliases from a URL or file'
+complete -c am -n "__fish_am_needs_command" -f -a "share" -d 'Generate a share command for posting aliases to a pastebin service'
+complete -c am -n "__fish_am_needs_command" -f -a "trust" -d 'Review and trust the project .aliases file in the current directory'
+complete -c am -n "__fish_am_needs_command" -f -a "untrust" -d 'Remove trust for the project .aliases file in the current directory'
+complete -c am -n "__fish_am_needs_command" -f -a "hook" -d 'Internal: called by the cd hook to load/unload project aliases'
+complete -c am -n "__fish_am_needs_command" -f -a "reload" -d 'Internal: called by the am wrapper to reload profile aliases after switching'
+complete -c am -n "__fish_am_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand add" -s p -l profile -d 'Profile to add the alias to (defaults to active profile)' -r
+complete -c am -n "__fish_am_using_subcommand add" -l sub -d 'Define a subcommand alias (repeatable: --sub short long)' -r
+complete -c am -n "__fish_am_using_subcommand add" -s l -l local -d 'Add to the project\'s .aliases file instead of a profile'
+complete -c am -n "__fish_am_using_subcommand add" -s g -l global -d 'Add as a global alias (always loaded, independent of profile)'
+complete -c am -n "__fish_am_using_subcommand add" -l raw -d 'Disable {{N}} template detection (treat command as literal)'
+complete -c am -n "__fish_am_using_subcommand add" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand add" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand remove" -s p -l profile -d 'Profile to remove the alias from (defaults to active profile)' -r
+complete -c am -n "__fish_am_using_subcommand remove" -l sub -d 'Subcommand path segments to complete the key (e.g. --sub b --sub l removes jj:b:l)' -r
+complete -c am -n "__fish_am_using_subcommand remove" -s l -l local -d 'Remove from the project\'s .aliases file instead of a profile'
+complete -c am -n "__fish_am_using_subcommand remove" -s g -l global -d 'Remove a global alias'
+complete -c am -n "__fish_am_using_subcommand remove" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand remove" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand ls" -s u -l used -d 'Show only active profiles and loaded project aliases'
+complete -c am -n "__fish_am_using_subcommand ls" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand ls" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand status" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand status" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "add" -d 'Add a new profile'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "use" -d 'Toggle one or more profiles as active/inactive, optionally at a specific priority'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "remove" -d 'Remove a profile'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "list" -d 'List all profiles'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from remove" -s f -l force -d 'Skip confirmation prompt'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from remove" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from remove" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from list" -s u -l used -d 'Show only active profiles and loaded project aliases'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from list" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "add" -d 'Add a new profile'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "use" -d 'Toggle one or more profiles as active/inactive, optionally at a specific priority'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "remove" -d 'Remove a profile'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "list" -d 'List all profiles'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand init" -s f -l force -d 'Force re-initialisation: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling `use_abbr`'
+complete -c am -n "__fish_am_using_subcommand init" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand setup" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
+complete -c am -n "__fish_am_using_subcommand use" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand use" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand tui" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand tui" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand export" -s p -l profile -d 'Operate on specific profile(s) — can be repeated' -r
+complete -c am -n "__fish_am_using_subcommand export" -s l -l local -d 'Operate on project-local aliases'
+complete -c am -n "__fish_am_using_subcommand export" -s g -l global -d 'Operate on global aliases'
+complete -c am -n "__fish_am_using_subcommand export" -l all -d 'Operate on everything (global + all profiles + local)'
+complete -c am -n "__fish_am_using_subcommand export" -s b -l base64 -d 'Encode output as base64'
+complete -c am -n "__fish_am_using_subcommand export" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand export" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand import" -s p -l profile -d 'Operate on specific profile(s) — can be repeated' -r
+complete -c am -n "__fish_am_using_subcommand import" -s l -l local -d 'Operate on project-local aliases'
+complete -c am -n "__fish_am_using_subcommand import" -s g -l global -d 'Operate on global aliases'
+complete -c am -n "__fish_am_using_subcommand import" -l all -d 'Operate on everything (global + all profiles + local)'
+complete -c am -n "__fish_am_using_subcommand import" -s b -l base64 -d 'Decode base64 input before parsing'
+complete -c am -n "__fish_am_using_subcommand import" -s y -l yes -d 'Skip all confirmation prompts'
+complete -c am -n "__fish_am_using_subcommand import" -l trust -d 'DANGER: Skip safety checks for suspicious content (escape sequences). Only use for your own exports. Never trust external input blindly — it can carry invisible escape sequences that hide malicious commands'
+complete -c am -n "__fish_am_using_subcommand import" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand import" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand share" -s p -l profile -d 'Operate on specific profile(s) — can be repeated' -r
+complete -c am -n "__fish_am_using_subcommand share" -s l -l local -d 'Operate on project-local aliases'
+complete -c am -n "__fish_am_using_subcommand share" -s g -l global -d 'Operate on global aliases'
+complete -c am -n "__fish_am_using_subcommand share" -l all -d 'Operate on everything (global + all profiles + local)'
+complete -c am -n "__fish_am_using_subcommand share" -l termbin -d 'Generate command for termbin.com (netcat)'
+complete -c am -n "__fish_am_using_subcommand share" -l paste-rs -d 'Generate command for paste.rs (curl)'
+complete -c am -n "__fish_am_using_subcommand share" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand share" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand trust" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand trust" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand untrust" -s f -l forget -d 'Forget the path entirely (remove from security tracking instead of marking untrusted)'
+complete -c am -n "__fish_am_using_subcommand untrust" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand untrust" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand hook" -s q -l quiet -d 'Suppress info and warning messages (still unloads/loads aliases)'
+complete -c am -n "__fish_am_using_subcommand hook" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand hook" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand reload" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand reload" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "add" -d 'Add a new alias'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "remove" -d 'Remove an alias'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "ls" -d 'List all profiles and project aliases'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "status" -d 'Check if the shell is set up correctly'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "profile" -d 'Manage profiles (defaults to listing when no subcommand given)'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "init" -d 'Print shell init code'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "setup" -d 'Guided setup — adds amoxide to your shell profile'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "use" -d 'Shortcut for `am profile use` — toggle one or more profiles'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "tui" -d 'Launch the interactive TUI for managing aliases and profiles'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "export" -d 'Export aliases to stdout as TOML'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "import" -d 'Import aliases from a URL or file'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "share" -d 'Generate a share command for posting aliases to a pastebin service'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "trust" -d 'Review and trust the project .aliases file in the current directory'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "untrust" -d 'Remove trust for the project .aliases file in the current directory'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "hook" -d 'Internal: called by the cd hook to load/unload project aliases'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "reload" -d 'Internal: called by the am wrapper to reload profile aliases after switching'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand help; and __fish_seen_subcommand_from profile" -f -a "add" -d 'Add a new profile'
+complete -c am -n "__fish_am_using_subcommand help; and __fish_seen_subcommand_from profile" -f -a "use" -d 'Toggle one or more profiles as active/inactive, optionally at a specific priority'
+complete -c am -n "__fish_am_using_subcommand help; and __fish_seen_subcommand_from profile" -f -a "remove" -d 'Remove a profile'
+complete -c am -n "__fish_am_using_subcommand help; and __fish_seen_subcommand_from profile" -f -a "list" -d 'List all profiles'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_deep_chain.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_deep_chain.snap
@@ -139,6 +139,7 @@ complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcomman
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "remove" -d 'Remove a profile'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "list" -d 'List all profiles'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand init" -s f -l force -d 'Force re-initialisation: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling `use_abbr`'
 complete -c am -n "__fish_am_using_subcommand init" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_force_no_previous.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_force_no_previous.snap
@@ -2,6 +2,8 @@
 source: crates/am/tests/snapshots.rs
 expression: output
 ---
+set -e _AM_PROJECT_ALIASES
+set -e _AM_PROJECT_PATH
 alias gs "git status"
 set -gx _AM_ALIASES "gs"
 set -e _AM_PROFILE_ALIASES

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_force_no_previous.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_force_no_previous.snap
@@ -1,0 +1,205 @@
+---
+source: crates/am/tests/snapshots.rs
+expression: output
+---
+alias gs "git status"
+set -gx _AM_ALIASES "gs"
+set -e _AM_PROFILE_ALIASES
+
+# am wrapper: reload aliases after mutations
+function am --wraps=am
+    command am $argv
+    set -l am_status $status
+    if test $am_status -ne 0
+        return $am_status
+    end
+    # tui may have changed anything → always reload after
+    if begin; test "$argv[1]" = tui; or test "$argv[1]" = t; end
+        command am reload fish | source
+        command am hook fish | source
+        return
+    end
+    # top-level use → reload aliases
+    if begin; test "$argv[1]" = use; or test "$argv[1]" = u; end
+        command am reload fish | source
+        return
+    end
+    # profile mutation → reload aliases
+    if begin; test "$argv[1]" = profile; or test "$argv[1]" = p; end
+        if begin; test "$argv[2]" = use; or test "$argv[2]" = u; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
+            command am reload fish | source
+        end
+    else if begin; test "$argv[1]" = add; or test "$argv[1]" = a; or test "$argv[1]" = remove; or test "$argv[1]" = r; end
+        if contains -- -l $argv; or contains -- --local $argv
+            # local alias change → reload project aliases
+            command am hook fish | source
+        else
+            # profile/global alias change → reload
+            command am reload fish | source
+        end
+    else if test "$argv[1]" = trust
+        command am hook fish | source
+    else if test "$argv[1]" = untrust
+        command am hook --quiet fish | source
+    end
+end
+
+# am cd hook
+function __am_hook --on-variable PWD
+    am hook fish | source
+end
+__am_hook
+
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_am_global_optspecs
+	string join \n h/help V/version
+end
+
+function __fish_am_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_am_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_am_using_subcommand
+	set -l cmd (__fish_am_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c am -n "__fish_am_needs_command" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_needs_command" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_needs_command" -f -a "add" -d 'Add a new alias'
+complete -c am -n "__fish_am_needs_command" -f -a "remove" -d 'Remove an alias'
+complete -c am -n "__fish_am_needs_command" -f -a "ls" -d 'List all profiles and project aliases'
+complete -c am -n "__fish_am_needs_command" -f -a "status" -d 'Check if the shell is set up correctly'
+complete -c am -n "__fish_am_needs_command" -f -a "profile" -d 'Manage profiles (defaults to listing when no subcommand given)'
+complete -c am -n "__fish_am_needs_command" -f -a "init" -d 'Print shell init code'
+complete -c am -n "__fish_am_needs_command" -f -a "setup" -d 'Guided setup — adds amoxide to your shell profile'
+complete -c am -n "__fish_am_needs_command" -f -a "use" -d 'Shortcut for `am profile use` — toggle one or more profiles'
+complete -c am -n "__fish_am_needs_command" -f -a "tui" -d 'Launch the interactive TUI for managing aliases and profiles'
+complete -c am -n "__fish_am_needs_command" -f -a "export" -d 'Export aliases to stdout as TOML'
+complete -c am -n "__fish_am_needs_command" -f -a "import" -d 'Import aliases from a URL or file'
+complete -c am -n "__fish_am_needs_command" -f -a "share" -d 'Generate a share command for posting aliases to a pastebin service'
+complete -c am -n "__fish_am_needs_command" -f -a "trust" -d 'Review and trust the project .aliases file in the current directory'
+complete -c am -n "__fish_am_needs_command" -f -a "untrust" -d 'Remove trust for the project .aliases file in the current directory'
+complete -c am -n "__fish_am_needs_command" -f -a "hook" -d 'Internal: called by the cd hook to load/unload project aliases'
+complete -c am -n "__fish_am_needs_command" -f -a "reload" -d 'Internal: called by the am wrapper to reload profile aliases after switching'
+complete -c am -n "__fish_am_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand add" -s p -l profile -d 'Profile to add the alias to (defaults to active profile)' -r
+complete -c am -n "__fish_am_using_subcommand add" -l sub -d 'Define a subcommand alias (repeatable: --sub short long)' -r
+complete -c am -n "__fish_am_using_subcommand add" -s l -l local -d 'Add to the project\'s .aliases file instead of a profile'
+complete -c am -n "__fish_am_using_subcommand add" -s g -l global -d 'Add as a global alias (always loaded, independent of profile)'
+complete -c am -n "__fish_am_using_subcommand add" -l raw -d 'Disable {{N}} template detection (treat command as literal)'
+complete -c am -n "__fish_am_using_subcommand add" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand add" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand remove" -s p -l profile -d 'Profile to remove the alias from (defaults to active profile)' -r
+complete -c am -n "__fish_am_using_subcommand remove" -l sub -d 'Subcommand path segments to complete the key (e.g. --sub b --sub l removes jj:b:l)' -r
+complete -c am -n "__fish_am_using_subcommand remove" -s l -l local -d 'Remove from the project\'s .aliases file instead of a profile'
+complete -c am -n "__fish_am_using_subcommand remove" -s g -l global -d 'Remove a global alias'
+complete -c am -n "__fish_am_using_subcommand remove" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand remove" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand ls" -s u -l used -d 'Show only active profiles and loaded project aliases'
+complete -c am -n "__fish_am_using_subcommand ls" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand ls" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand status" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand status" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "add" -d 'Add a new profile'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "use" -d 'Toggle one or more profiles as active/inactive, optionally at a specific priority'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "remove" -d 'Remove a profile'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "list" -d 'List all profiles'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from remove" -s f -l force -d 'Skip confirmation prompt'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from remove" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from remove" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from list" -s u -l used -d 'Show only active profiles and loaded project aliases'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from list" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "add" -d 'Add a new profile'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "use" -d 'Toggle one or more profiles as active/inactive, optionally at a specific priority'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "remove" -d 'Remove a profile'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "list" -d 'List all profiles'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand init" -s f -l force -d 'Force re-initialisation: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling `use_abbr`'
+complete -c am -n "__fish_am_using_subcommand init" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand setup" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
+complete -c am -n "__fish_am_using_subcommand use" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand use" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand tui" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand tui" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand export" -s p -l profile -d 'Operate on specific profile(s) — can be repeated' -r
+complete -c am -n "__fish_am_using_subcommand export" -s l -l local -d 'Operate on project-local aliases'
+complete -c am -n "__fish_am_using_subcommand export" -s g -l global -d 'Operate on global aliases'
+complete -c am -n "__fish_am_using_subcommand export" -l all -d 'Operate on everything (global + all profiles + local)'
+complete -c am -n "__fish_am_using_subcommand export" -s b -l base64 -d 'Encode output as base64'
+complete -c am -n "__fish_am_using_subcommand export" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand export" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand import" -s p -l profile -d 'Operate on specific profile(s) — can be repeated' -r
+complete -c am -n "__fish_am_using_subcommand import" -s l -l local -d 'Operate on project-local aliases'
+complete -c am -n "__fish_am_using_subcommand import" -s g -l global -d 'Operate on global aliases'
+complete -c am -n "__fish_am_using_subcommand import" -l all -d 'Operate on everything (global + all profiles + local)'
+complete -c am -n "__fish_am_using_subcommand import" -s b -l base64 -d 'Decode base64 input before parsing'
+complete -c am -n "__fish_am_using_subcommand import" -s y -l yes -d 'Skip all confirmation prompts'
+complete -c am -n "__fish_am_using_subcommand import" -l trust -d 'DANGER: Skip safety checks for suspicious content (escape sequences). Only use for your own exports. Never trust external input blindly — it can carry invisible escape sequences that hide malicious commands'
+complete -c am -n "__fish_am_using_subcommand import" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand import" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand share" -s p -l profile -d 'Operate on specific profile(s) — can be repeated' -r
+complete -c am -n "__fish_am_using_subcommand share" -s l -l local -d 'Operate on project-local aliases'
+complete -c am -n "__fish_am_using_subcommand share" -s g -l global -d 'Operate on global aliases'
+complete -c am -n "__fish_am_using_subcommand share" -l all -d 'Operate on everything (global + all profiles + local)'
+complete -c am -n "__fish_am_using_subcommand share" -l termbin -d 'Generate command for termbin.com (netcat)'
+complete -c am -n "__fish_am_using_subcommand share" -l paste-rs -d 'Generate command for paste.rs (curl)'
+complete -c am -n "__fish_am_using_subcommand share" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand share" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand trust" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand trust" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand untrust" -s f -l forget -d 'Forget the path entirely (remove from security tracking instead of marking untrusted)'
+complete -c am -n "__fish_am_using_subcommand untrust" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand untrust" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand hook" -s q -l quiet -d 'Suppress info and warning messages (still unloads/loads aliases)'
+complete -c am -n "__fish_am_using_subcommand hook" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand hook" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand reload" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand reload" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "add" -d 'Add a new alias'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "remove" -d 'Remove an alias'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "ls" -d 'List all profiles and project aliases'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "status" -d 'Check if the shell is set up correctly'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "profile" -d 'Manage profiles (defaults to listing when no subcommand given)'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "init" -d 'Print shell init code'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "setup" -d 'Guided setup — adds amoxide to your shell profile'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "use" -d 'Shortcut for `am profile use` — toggle one or more profiles'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "tui" -d 'Launch the interactive TUI for managing aliases and profiles'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "export" -d 'Export aliases to stdout as TOML'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "import" -d 'Import aliases from a URL or file'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "share" -d 'Generate a share command for posting aliases to a pastebin service'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "trust" -d 'Review and trust the project .aliases file in the current directory'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "untrust" -d 'Remove trust for the project .aliases file in the current directory'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "hook" -d 'Internal: called by the cd hook to load/unload project aliases'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "reload" -d 'Internal: called by the am wrapper to reload profile aliases after switching'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand help; and __fish_seen_subcommand_from profile" -f -a "add" -d 'Add a new profile'
+complete -c am -n "__fish_am_using_subcommand help; and __fish_seen_subcommand_from profile" -f -a "use" -d 'Toggle one or more profiles as active/inactive, optionally at a specific priority'
+complete -c am -n "__fish_am_using_subcommand help; and __fish_seen_subcommand_from profile" -f -a "remove" -d 'Remove a profile'
+complete -c am -n "__fish_am_using_subcommand help; and __fish_seen_subcommand_from profile" -f -a "list" -d 'List all profiles'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_force_with_tracked_aliases.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_force_with_tracked_aliases.snap
@@ -6,6 +6,8 @@ functions -e gs
 abbr --query gs; and abbr --erase gs
 functions -e ll
 abbr --query ll; and abbr --erase ll
+set -e _AM_PROJECT_ALIASES
+set -e _AM_PROJECT_PATH
 alias gs "git status"
 alias ll "ls -lha"
 set -gx _AM_ALIASES "gs,ll"

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_force_with_tracked_aliases.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_force_with_tracked_aliases.snap
@@ -1,0 +1,210 @@
+---
+source: crates/am/tests/snapshots.rs
+expression: output
+---
+functions -e gs
+abbr --query gs; and abbr --erase gs
+functions -e ll
+abbr --query ll; and abbr --erase ll
+alias gs "git status"
+alias ll "ls -lha"
+set -gx _AM_ALIASES "gs,ll"
+set -e _AM_PROFILE_ALIASES
+
+# am wrapper: reload aliases after mutations
+function am --wraps=am
+    command am $argv
+    set -l am_status $status
+    if test $am_status -ne 0
+        return $am_status
+    end
+    # tui may have changed anything → always reload after
+    if begin; test "$argv[1]" = tui; or test "$argv[1]" = t; end
+        command am reload fish | source
+        command am hook fish | source
+        return
+    end
+    # top-level use → reload aliases
+    if begin; test "$argv[1]" = use; or test "$argv[1]" = u; end
+        command am reload fish | source
+        return
+    end
+    # profile mutation → reload aliases
+    if begin; test "$argv[1]" = profile; or test "$argv[1]" = p; end
+        if begin; test "$argv[2]" = use; or test "$argv[2]" = u; or test "$argv[2]" = add; or test "$argv[2]" = a; or test "$argv[2]" = remove; or test "$argv[2]" = r; end
+            command am reload fish | source
+        end
+    else if begin; test "$argv[1]" = add; or test "$argv[1]" = a; or test "$argv[1]" = remove; or test "$argv[1]" = r; end
+        if contains -- -l $argv; or contains -- --local $argv
+            # local alias change → reload project aliases
+            command am hook fish | source
+        else
+            # profile/global alias change → reload
+            command am reload fish | source
+        end
+    else if test "$argv[1]" = trust
+        command am hook fish | source
+    else if test "$argv[1]" = untrust
+        command am hook --quiet fish | source
+    end
+end
+
+# am cd hook
+function __am_hook --on-variable PWD
+    am hook fish | source
+end
+__am_hook
+
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_am_global_optspecs
+	string join \n h/help V/version
+end
+
+function __fish_am_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_am_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_am_using_subcommand
+	set -l cmd (__fish_am_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c am -n "__fish_am_needs_command" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_needs_command" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_needs_command" -f -a "add" -d 'Add a new alias'
+complete -c am -n "__fish_am_needs_command" -f -a "remove" -d 'Remove an alias'
+complete -c am -n "__fish_am_needs_command" -f -a "ls" -d 'List all profiles and project aliases'
+complete -c am -n "__fish_am_needs_command" -f -a "status" -d 'Check if the shell is set up correctly'
+complete -c am -n "__fish_am_needs_command" -f -a "profile" -d 'Manage profiles (defaults to listing when no subcommand given)'
+complete -c am -n "__fish_am_needs_command" -f -a "init" -d 'Print shell init code'
+complete -c am -n "__fish_am_needs_command" -f -a "setup" -d 'Guided setup — adds amoxide to your shell profile'
+complete -c am -n "__fish_am_needs_command" -f -a "use" -d 'Shortcut for `am profile use` — toggle one or more profiles'
+complete -c am -n "__fish_am_needs_command" -f -a "tui" -d 'Launch the interactive TUI for managing aliases and profiles'
+complete -c am -n "__fish_am_needs_command" -f -a "export" -d 'Export aliases to stdout as TOML'
+complete -c am -n "__fish_am_needs_command" -f -a "import" -d 'Import aliases from a URL or file'
+complete -c am -n "__fish_am_needs_command" -f -a "share" -d 'Generate a share command for posting aliases to a pastebin service'
+complete -c am -n "__fish_am_needs_command" -f -a "trust" -d 'Review and trust the project .aliases file in the current directory'
+complete -c am -n "__fish_am_needs_command" -f -a "untrust" -d 'Remove trust for the project .aliases file in the current directory'
+complete -c am -n "__fish_am_needs_command" -f -a "hook" -d 'Internal: called by the cd hook to load/unload project aliases'
+complete -c am -n "__fish_am_needs_command" -f -a "reload" -d 'Internal: called by the am wrapper to reload profile aliases after switching'
+complete -c am -n "__fish_am_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand add" -s p -l profile -d 'Profile to add the alias to (defaults to active profile)' -r
+complete -c am -n "__fish_am_using_subcommand add" -l sub -d 'Define a subcommand alias (repeatable: --sub short long)' -r
+complete -c am -n "__fish_am_using_subcommand add" -s l -l local -d 'Add to the project\'s .aliases file instead of a profile'
+complete -c am -n "__fish_am_using_subcommand add" -s g -l global -d 'Add as a global alias (always loaded, independent of profile)'
+complete -c am -n "__fish_am_using_subcommand add" -l raw -d 'Disable {{N}} template detection (treat command as literal)'
+complete -c am -n "__fish_am_using_subcommand add" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand add" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand remove" -s p -l profile -d 'Profile to remove the alias from (defaults to active profile)' -r
+complete -c am -n "__fish_am_using_subcommand remove" -l sub -d 'Subcommand path segments to complete the key (e.g. --sub b --sub l removes jj:b:l)' -r
+complete -c am -n "__fish_am_using_subcommand remove" -s l -l local -d 'Remove from the project\'s .aliases file instead of a profile'
+complete -c am -n "__fish_am_using_subcommand remove" -s g -l global -d 'Remove a global alias'
+complete -c am -n "__fish_am_using_subcommand remove" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand remove" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand ls" -s u -l used -d 'Show only active profiles and loaded project aliases'
+complete -c am -n "__fish_am_using_subcommand ls" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand ls" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand status" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand status" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "add" -d 'Add a new profile'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "use" -d 'Toggle one or more profiles as active/inactive, optionally at a specific priority'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "remove" -d 'Remove a profile'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "list" -d 'List all profiles'
+complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subcommand_from add use remove list help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from remove" -s f -l force -d 'Skip confirmation prompt'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from remove" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from remove" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from list" -s u -l used -d 'Show only active profiles and loaded project aliases'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from list" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from list" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "add" -d 'Add a new profile'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "use" -d 'Toggle one or more profiles as active/inactive, optionally at a specific priority'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "remove" -d 'Remove a profile'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "list" -d 'List all profiles'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand init" -s f -l force -d 'Force re-initialisation: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling `use_abbr`'
+complete -c am -n "__fish_am_using_subcommand init" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand setup" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
+complete -c am -n "__fish_am_using_subcommand use" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand use" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand tui" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand tui" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand export" -s p -l profile -d 'Operate on specific profile(s) — can be repeated' -r
+complete -c am -n "__fish_am_using_subcommand export" -s l -l local -d 'Operate on project-local aliases'
+complete -c am -n "__fish_am_using_subcommand export" -s g -l global -d 'Operate on global aliases'
+complete -c am -n "__fish_am_using_subcommand export" -l all -d 'Operate on everything (global + all profiles + local)'
+complete -c am -n "__fish_am_using_subcommand export" -s b -l base64 -d 'Encode output as base64'
+complete -c am -n "__fish_am_using_subcommand export" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand export" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand import" -s p -l profile -d 'Operate on specific profile(s) — can be repeated' -r
+complete -c am -n "__fish_am_using_subcommand import" -s l -l local -d 'Operate on project-local aliases'
+complete -c am -n "__fish_am_using_subcommand import" -s g -l global -d 'Operate on global aliases'
+complete -c am -n "__fish_am_using_subcommand import" -l all -d 'Operate on everything (global + all profiles + local)'
+complete -c am -n "__fish_am_using_subcommand import" -s b -l base64 -d 'Decode base64 input before parsing'
+complete -c am -n "__fish_am_using_subcommand import" -s y -l yes -d 'Skip all confirmation prompts'
+complete -c am -n "__fish_am_using_subcommand import" -l trust -d 'DANGER: Skip safety checks for suspicious content (escape sequences). Only use for your own exports. Never trust external input blindly — it can carry invisible escape sequences that hide malicious commands'
+complete -c am -n "__fish_am_using_subcommand import" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand import" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand share" -s p -l profile -d 'Operate on specific profile(s) — can be repeated' -r
+complete -c am -n "__fish_am_using_subcommand share" -s l -l local -d 'Operate on project-local aliases'
+complete -c am -n "__fish_am_using_subcommand share" -s g -l global -d 'Operate on global aliases'
+complete -c am -n "__fish_am_using_subcommand share" -l all -d 'Operate on everything (global + all profiles + local)'
+complete -c am -n "__fish_am_using_subcommand share" -l termbin -d 'Generate command for termbin.com (netcat)'
+complete -c am -n "__fish_am_using_subcommand share" -l paste-rs -d 'Generate command for paste.rs (curl)'
+complete -c am -n "__fish_am_using_subcommand share" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand share" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand trust" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand trust" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand untrust" -s f -l forget -d 'Forget the path entirely (remove from security tracking instead of marking untrusted)'
+complete -c am -n "__fish_am_using_subcommand untrust" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand untrust" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand hook" -s q -l quiet -d 'Suppress info and warning messages (still unloads/loads aliases)'
+complete -c am -n "__fish_am_using_subcommand hook" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand hook" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand reload" -s h -l help -d 'Print help'
+complete -c am -n "__fish_am_using_subcommand reload" -s V -l version -d 'Print version'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "add" -d 'Add a new alias'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "remove" -d 'Remove an alias'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "ls" -d 'List all profiles and project aliases'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "status" -d 'Check if the shell is set up correctly'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "profile" -d 'Manage profiles (defaults to listing when no subcommand given)'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "init" -d 'Print shell init code'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "setup" -d 'Guided setup — adds amoxide to your shell profile'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "use" -d 'Shortcut for `am profile use` — toggle one or more profiles'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "tui" -d 'Launch the interactive TUI for managing aliases and profiles'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "export" -d 'Export aliases to stdout as TOML'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "import" -d 'Import aliases from a URL or file'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "share" -d 'Generate a share command for posting aliases to a pastebin service'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "trust" -d 'Review and trust the project .aliases file in the current directory'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "untrust" -d 'Remove trust for the project .aliases file in the current directory'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "hook" -d 'Internal: called by the cd hook to load/unload project aliases'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "reload" -d 'Internal: called by the am wrapper to reload profile aliases after switching'
+complete -c am -n "__fish_am_using_subcommand help; and not __fish_seen_subcommand_from add remove ls status profile init setup use tui export import share trust untrust hook reload help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand help; and __fish_seen_subcommand_from profile" -f -a "add" -d 'Add a new profile'
+complete -c am -n "__fish_am_using_subcommand help; and __fish_seen_subcommand_from profile" -f -a "use" -d 'Toggle one or more profiles as active/inactive, optionally at a specific priority'
+complete -c am -n "__fish_am_using_subcommand help; and __fish_seen_subcommand_from profile" -f -a "remove" -d 'Remove a profile'
+complete -c am -n "__fish_am_using_subcommand help; and __fish_seen_subcommand_from profile" -f -a "list" -d 'List all profiles'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_globals_and_multi_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_globals_and_multi_profile.snap
@@ -142,6 +142,7 @@ complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcomman
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "remove" -d 'Remove a profile'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "list" -d 'List all profiles'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand init" -s f -l force -d 'Force re-initialisation: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling `use_abbr`'
 complete -c am -n "__fish_am_using_subcommand init" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_multi_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_multi_profile.snap
@@ -141,6 +141,7 @@ complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcomman
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "remove" -d 'Remove a profile'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "list" -d 'List all profiles'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand init" -s f -l force -d 'Force re-initialisation: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling `use_abbr`'
 complete -c am -n "__fish_am_using_subcommand init" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_simple_profile.snap
@@ -138,6 +138,7 @@ complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcomman
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "remove" -d 'Remove a profile'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "list" -d 'List all profiles'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand init" -s f -l force -d 'Force re-initialisation: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling `use_abbr`'
 complete -c am -n "__fish_am_using_subcommand init" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_globals.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_globals.snap
@@ -138,6 +138,7 @@ complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcomman
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "remove" -d 'Remove a profile'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "list" -d 'List all profiles'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand init" -s f -l force -d 'Force re-initialisation: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling `use_abbr`'
 complete -c am -n "__fish_am_using_subcommand init" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_simple_subcommands.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_simple_subcommands.snap
@@ -147,6 +147,7 @@ complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcomman
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "remove" -d 'Remove a profile'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "list" -d 'List all profiles'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c am -n "__fish_am_using_subcommand init" -s f -l force -d 'Force re-initialisation: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling `use_abbr`'
 complete -c am -n "__fish_am_using_subcommand init" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
@@ -230,6 +230,8 @@ Register-ArgumentCompleter -Native -CommandName 'am' -ScriptBlock {
             break
         }
         'am;init' {
+            [System.Management.Automation.CompletionResult]::new('-f', '-f', [System.Management.Automation.CompletionResultType]::ParameterName, 'Force re-initialisation: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling `use_abbr`')
+            [System.Management.Automation.CompletionResult]::new('--force', '--force', [System.Management.Automation.CompletionResultType]::ParameterName, 'Force re-initialisation: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling `use_abbr`')
             [System.Management.Automation.CompletionResult]::new('-h', '-h', [System.Management.Automation.CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             [System.Management.Automation.CompletionResult]::new('--help', '--help', [System.Management.Automation.CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             [System.Management.Automation.CompletionResult]::new('-V', '-V ', [System.Management.Automation.CompletionResultType]::ParameterName, 'Print version')

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_zsh_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_zsh_simple_profile.snap
@@ -225,7 +225,7 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help (see more with '\''--help'\'')]' \
 '-V[Print version]' \
 '--version[Print version]' \
-':shell:(bash fish powershell zsh)' \
+':shell:(bash brush fish powershell zsh)' \
 && ret=0
 ;;
 (setup)
@@ -234,7 +234,7 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-':shell:(bash fish powershell zsh)' \
+':shell:(bash brush fish powershell zsh)' \
 && ret=0
 ;;
 (use)
@@ -339,7 +339,7 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-':shell:(bash fish powershell zsh)' \
+':shell:(bash brush fish powershell zsh)' \
 && ret=0
 ;;
 (reload)
@@ -348,7 +348,7 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-':shell:(bash fish powershell zsh)' \
+':shell:(bash brush fish powershell zsh)' \
 && ret=0
 ;;
 (help)

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_zsh_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_zsh_simple_profile.snap
@@ -219,6 +219,8 @@ esac
 ;;
 (init)
 _arguments "${_arguments_options[@]}" : \
+'-f[Force re-initialisation\: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling \`use_abbr\`]' \
+'--force[Force re-initialisation\: unload all previously tracked aliases (both alias and function forms) before re-loading. Use after config changes such as toggling \`use_abbr\`]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
 '-V[Print version]' \

--- a/website/advanced/config-files.md
+++ b/website/advanced/config-files.md
@@ -60,7 +60,11 @@ function cmf
 end
 ```
 
-To enable this setting, edit `~/.config/amoxide/config.toml` manually and add the `[shell.fish]` block shown above. Then run `am reload fish` (or start a new shell session) to apply the change.
+To enable this setting, edit `~/.config/amoxide/config.toml` manually and add the `[shell.fish]` block shown above. Then [reinitialise in place](/guide/setup#reinitialising-without-restarting) to apply the change without restarting your shell:
+
+```fish
+am init -f fish | source
+```
 
 ## `profiles.toml` — Profile Definitions
 

--- a/website/de/advanced/config-files.md
+++ b/website/de/advanced/config-files.md
@@ -60,7 +60,11 @@ function cmf
 end
 ```
 
-Um diese Einstellung zu aktivieren, bearbeite `~/.config/amoxide/config.toml` manuell und füge den oben gezeigten `[shell.fish]`-Block hinzu. Dann führe `am reload fish` aus (oder starte eine neue Shell-Session), um die Änderung anzuwenden.
+Um diese Einstellung zu aktivieren, bearbeite `~/.config/amoxide/config.toml` manuell und füge den oben gezeigten `[shell.fish]`-Block hinzu. Dann [neu initialisieren ohne Neustart](/de/guide/setup#neu-initialisieren-ohne-neustart), um die Änderung anzuwenden:
+
+```fish
+am init -f fish | source
+```
 
 ## `profiles.toml` — Profildefinitionen
 

--- a/website/de/faq.md
+++ b/website/de/faq.md
@@ -45,4 +45,26 @@ brew install sassman/tap/amoxide-tui
 
 Siehe [alle Installationsoptionen](/de/guide/installation#am-tui-installieren) für Shell-Skript, PowerShell und Cargo.
 
+## Ich habe meine Config-Datei manuell geändert — wie wende ich die Änderungen ohne Neustart der Shell an?
+
+Führe `am init -f <shell>` aus, um die Shell neu zu initialisieren. Das entlädt alle aktuellen Aliase und lädt alles aus der Config neu, einschließlich Einstellungsänderungen wie [`use_abbr = true`](/de/advanced/config-files#fish-shell-fish) in Fish. Weitere Details unter [Neu initialisieren ohne Neustart](/de/guide/setup#neu-initialisieren-ohne-neustart).
+
+::: code-group
+
+```fish [Fish]
+am init -f fish | source
+```
+
+```zsh [Zsh]
+eval "$(am init -f zsh)"
+```
+
+```powershell [PowerShell]
+(am init -f powershell) -join "`n" | Invoke-Expression
+```
+
+```bash [Bash]
+eval "$(am init -f bash)"
+```
+
 :::

--- a/website/de/guide/setup.md
+++ b/website/de/guide/setup.md
@@ -72,7 +72,7 @@ Der `am init`-Befehl macht zwei Dinge:
 
 ## Neu initialisieren ohne Neustart
 
-Wenn du Aliase hinzugefügt oder geändert hast und diese in der aktuellen Shell-Session anwenden möchtest, ohne ein neues Terminal zu öffnen, verwende das `-f` / `--force`-Flag:
+Im seltenen Fall, dass du die Config-Dateien direkt bearbeitet hast (statt `am` oder das TUI zu verwenden) und die Änderungen in der aktuellen Shell-Session anwenden möchtest, ohne ein neues Terminal zu öffnen, verwende das `-f` / `--force`-Flag:
 
 ::: code-group
 

--- a/website/de/guide/setup.md
+++ b/website/de/guide/setup.md
@@ -70,6 +70,32 @@ Der `am init`-Befehl macht zwei Dinge:
 1. **Lädt Aliase** aus deinen aktiven Profilen in die aktuelle Shell
 2. **Installiert einen cd-Hook**, der automatisch Projekt-Aliase (aus `.aliases`-Dateien) lädt und entlädt, wenn du das Verzeichnis wechselst
 
+## Neu initialisieren ohne Neustart
+
+Wenn du Aliase hinzugefügt oder geändert hast und diese in der aktuellen Shell-Session anwenden möchtest, ohne ein neues Terminal zu öffnen, verwende das `-f` / `--force`-Flag:
+
+::: code-group
+
+```fish [Fish]
+am init -f fish | source
+```
+
+```zsh [Zsh]
+eval "$(am init -f zsh)"
+```
+
+```powershell [PowerShell]
+(am init -f powershell) -join "`n" | Invoke-Expression
+```
+
+```bash [Bash]
+eval "$(am init -f bash)"
+```
+
+:::
+
+Dabei werden alle zuvor definierten Aliase zuerst entladen und dann alles neu geladen — das gleiche Ergebnis wie das Öffnen einer neuen Shell, aber ohne die aktuelle Session zu verlassen.
+
 ## Setup überprüfen
 
 Prüfe, ob alles korrekt konfiguriert ist:

--- a/website/faq.md
+++ b/website/faq.md
@@ -3,7 +3,7 @@ head:
   - - script
     - type: application/ld+json
     - >-
-      {"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What shells are supported?","acceptedAnswer":{"@type":"Answer","text":"amoxide supports Fish (fully), PowerShell 5.1+7, Zsh, Bash 3.2+, and Brush (bash-compatible). Nushell support is planned."}},{"@type":"Question","name":"How is amoxide different from shell aliases in dotfiles?","acceptedAnswer":{"@type":"Answer","text":"Traditional aliases are static and defined once in .bashrc or .zshrc. amoxide adds: Profiles (named groups you can activate/deactivate), Project aliases (auto-loaded per directory like direnv), Parameterized aliases (template syntax for composable commands), and multiple active profiles with layered precedence."}},{"@type":"Question","name":"Where are my aliases stored?","acceptedAnswer":{"@type":"Answer","text":"Global aliases are stored in ~/.config/amoxide/config.toml. Profile aliases are stored in ~/.config/amoxide/profiles.toml. Project aliases are stored in a .aliases file in the project directory."}},{"@type":"Question","name":"Can I use amoxide alongside my existing shell aliases?","acceptedAnswer":{"@type":"Answer","text":"Yes. amoxide aliases coexist with your shell's native aliases. If there is a name conflict, amoxide's alias takes precedence while it is active."}},{"@type":"Question","name":"What is am-tui?","acceptedAnswer":{"@type":"Answer","text":"am-tui is a separate binary (amoxide-tui) that provides an interactive terminal UI for managing aliases visually. Run it with: am tui. Install via: brew install sassman/tap/amoxide-tui"}}]}
+      {"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"What shells are supported?","acceptedAnswer":{"@type":"Answer","text":"amoxide supports Fish (fully), PowerShell 5.1+7, Zsh, Bash 3.2+, and Brush (bash-compatible). Nushell support is planned."}},{"@type":"Question","name":"How is amoxide different from shell aliases in dotfiles?","acceptedAnswer":{"@type":"Answer","text":"Traditional aliases are static and defined once in .bashrc or .zshrc. amoxide adds: Profiles (named groups you can activate/deactivate), Project aliases (auto-loaded per directory like direnv), Parameterized aliases (template syntax for composable commands), and multiple active profiles with layered precedence."}},{"@type":"Question","name":"Where are my aliases stored?","acceptedAnswer":{"@type":"Answer","text":"Global aliases are stored in ~/.config/amoxide/config.toml. Profile aliases are stored in ~/.config/amoxide/profiles.toml. Project aliases are stored in a .aliases file in the project directory."}},{"@type":"Question","name":"Can I use amoxide alongside my existing shell aliases?","acceptedAnswer":{"@type":"Answer","text":"Yes. amoxide aliases coexist with your shell's native aliases. If there is a name conflict, amoxide's alias takes precedence while it is active."}},{"@type":"Question","name":"What is am-tui?","acceptedAnswer":{"@type":"Answer","text":"am-tui is a separate binary (amoxide-tui) that provides an interactive terminal UI for managing aliases visually. Run it with: am tui. Install via: brew install sassman/tap/amoxide-tui"}},{"@type":"Question","name":"I changed my config file manually — how do I apply the changes without restarting my shell?","acceptedAnswer":{"@type":"Answer","text":"Run am init -f <shell> to reinitialise in place. This unloads all current aliases and reloads everything from your config, including any setting changes like use_abbr = true in Fish."}}]}
 ---
 
 # FAQ
@@ -53,5 +53,27 @@ brew install sassman/tap/amoxide-tui
 ```
 
 See [all installation options](/guide/installation#installing-am-tui) for Shell Script, PowerShell, and Cargo.
+
+## I changed my config file manually — how do I apply the changes without restarting my shell?
+
+Run `am init -f <shell>` to reinitialise in place. This unloads all current aliases and reloads everything from your config, including any setting changes like [`use_abbr = true`](/advanced/config-files#fish-shell-fish) in Fish. See [Reinitialising Without Restarting](/guide/setup#reinitialising-without-restarting) for full details.
+
+::: code-group
+
+```fish [Fish]
+am init -f fish | source
+```
+
+```zsh [Zsh]
+eval "$(am init -f zsh)"
+```
+
+```powershell [PowerShell]
+(am init -f powershell) -join "`n" | Invoke-Expression
+```
+
+```bash [Bash]
+eval "$(am init -f bash)"
+```
 
 :::

--- a/website/guide/setup.md
+++ b/website/guide/setup.md
@@ -76,7 +76,7 @@ The `am init` command does two things:
 
 ## Reinitialising Without Restarting
 
-If you've added or changed aliases and want them applied to your current shell session without opening a new terminal, use the `-f` / `--force` flag:
+In the rare case that you have edited the config files directly (rather than using `am` or the TUI) and want the changes applied to your current shell session without opening a new terminal, use the `-f` / `--force` flag:
 
 ::: code-group
 

--- a/website/guide/setup.md
+++ b/website/guide/setup.md
@@ -74,6 +74,32 @@ The `am init` command does two things:
 1. **Loads aliases** from your active profiles into the current shell
 2. **Installs a cd hook** that automatically loads/unloads project aliases (from `.aliases` files) when you change directories
 
+## Reinitialising Without Restarting
+
+If you've added or changed aliases and want them applied to your current shell session without opening a new terminal, use the `-f` / `--force` flag:
+
+::: code-group
+
+```fish [Fish]
+am init -f fish | source
+```
+
+```zsh [Zsh]
+eval "$(am init -f zsh)"
+```
+
+```powershell [PowerShell]
+(am init -f powershell) -join "`n" | Invoke-Expression
+```
+
+```bash [Bash]
+eval "$(am init -f bash)"
+```
+
+:::
+
+This unloads all previously defined aliases first, then reloads everything fresh — the same result as opening a new shell, but without leaving your current session.
+
 ## Verify Setup
 
 Check that everything is configured correctly:


### PR DESCRIPTION
- adds `-f`/`--force` to `am init` so users can reinitialise without opening a new shell session
- emits `force_unalias` cleanup for every tracked alias before re-emitting init code, preventing stale definitions
- clears project-alias tracking env vars on `--force` so the cd hook reloads project aliases correctly
- adds `force_unalias` to `ShellAdapter` trait with a sensible default; Fish overrides it with `functions --erase`
- renames `Shell` trait → `ShellAdapter` and `Shells` enum → `Shell` for a cleaner public API
- extracts `Shell` enum into its own module (`shell_enum.rs`), `include!`-ed in `build.rs` — removes the hand-maintained stub that was missing `Brush`

Closes #84