### PR TITLE
fix(website): sync de showcase, add contribute page, fix sitemap URLs

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -18,7 +18,25 @@ try {
 }
 
 // Build showcase sidebar from community folder
-function buildShowcaseSidebar() {
+interface ShowcaseSidebarLabels {
+  showcase: string
+  allProfiles: string
+  contribute: string
+  byTag: string
+  byAuthor: string
+  byName: string
+  basePath: string
+}
+
+function buildShowcaseSidebar(labels: ShowcaseSidebarLabels = {
+  showcase: 'Showcase',
+  allProfiles: 'All Profiles',
+  contribute: 'Contribute',
+  byTag: 'By Tag',
+  byAuthor: 'By Author',
+  byName: 'By Name',
+  basePath: '/showcase',
+}) {
   const communityDir = path.resolve(__dirname, '../../community')
   const tags = new Set<string>()
   const authors = new Set<string>()
@@ -37,37 +55,38 @@ function buildShowcaseSidebar() {
   }
 
   const COLLAPSE_THRESHOLD = 10
+  const base = labels.basePath
 
   return [
     {
-      text: 'Showcase',
+      text: labels.showcase,
       items: [
-        { text: `All Profiles (${names.length})`, link: '/showcase/' },
-        { text: 'Contribute', link: '/showcase/contribute' },
+        { text: `${labels.allProfiles} (${names.length})`, link: `${base}/` },
+        { text: labels.contribute, link: `${base}/contribute` },
       ],
     },
     {
-      text: 'By Tag',
+      text: labels.byTag,
       collapsed: false,
       items: Array.from(tags).sort().map(tag => ({
         text: tag,
-        link: `/showcase/#tag=${tag}`,
+        link: `${base}/#tag=${tag}`,
       })),
     },
     {
-      text: 'By Author',
+      text: labels.byAuthor,
       collapsed: authors.size > COLLAPSE_THRESHOLD,
       items: Array.from(authors).sort().map(author => ({
         text: author,
-        link: `/showcase/#author=${author}`,
+        link: `${base}/#author=${author}`,
       })),
     },
     {
-      text: 'By Name',
+      text: labels.byName,
       collapsed: names.length > COLLAPSE_THRESHOLD,
       items: names.sort((a, b) => a.label.localeCompare(b.label)).map(n => ({
         text: n.label,
-        link: `/showcase/#name=${n.slug}`,
+        link: `${base}/#name=${n.slug}`,
       })),
     },
   ]
@@ -101,6 +120,16 @@ export default defineConfig({
   cleanUrls: true,
   sitemap: {
     hostname: 'https://amoxide.rs',
+    transformItems(items) {
+      return items.map(item => ({
+        ...item,
+        url: item.url.replace(/\.html$/, ''),
+        links: item.links?.map(link => ({
+          ...link,
+          url: link.url.replace(/\.html$/, ''),
+        })),
+      }))
+    },
   },
   transformHead({ pageData }) {
     const canonicalUrl = `https://amoxide.rs/${pageData.relativePath}`
@@ -242,6 +271,15 @@ export default defineConfig({
               ],
             },
           ],
+          '/de/showcase/': buildShowcaseSidebar({
+            showcase: 'Showcase',
+            allProfiles: 'Alle Profile',
+            contribute: 'Beitragen',
+            byTag: 'Nach Tag',
+            byAuthor: 'Nach Autor',
+            byName: 'Nach Name',
+            basePath: '/de/showcase',
+          }),
         },
       },
     },

--- a/website/de/showcase/contribute.md
+++ b/website/de/showcase/contribute.md
@@ -1,0 +1,131 @@
+# Profile teilen
+
+Hast du eine Profil-Sammlung, die andere nützlich finden könnten? So fügst du sie dem Showcase hinzu.
+
+## Voraussetzungen
+
+- [amoxide](https://github.com/sassman/amoxide-rs) installiert
+- Ein [GitHub](https://github.com)-Konto
+
+## Schritt für Schritt
+
+Angenommen, dein GitHub-Nutzername ist **john** und du möchtest deine Git-Profile für konventionelle Commits teilen.
+
+### 1. Repository forken
+
+Gehe zu [github.com/sassman/amoxide-rs](https://github.com/sassman/amoxide-rs) und klicke auf **Fork** (oben rechts). Dadurch wird deine eigene Kopie unter `github.com/john/amoxide-rs` erstellt.
+
+### 2. Fork klonen
+
+```bash
+git clone git@github.com:john/amoxide-rs.git
+cd amoxide-rs
+```
+
+### 3. Branch erstellen
+
+```bash
+git checkout -b community/john-git-conventional
+```
+
+### 4. Vorlage kopieren
+
+```bash
+cp -r community/TEMPLATE community/john-git-conventional
+```
+
+Das ergibt:
+
+```
+community/john-git-conventional/
+├── README.md     ← bearbeite diese Datei
+└── profiles.toml ← ersetze mit deinem Export
+```
+
+### 5. Profile exportieren
+
+Ersetze die Vorlagen-`profiles.toml` mit deinem eigentlichen Export:
+
+```bash
+am export -p git-conventional > community/john-git-conventional/profiles.toml
+```
+
+Oder exportiere mehrere Profile:
+
+```bash
+am export -p git -p git-conventional > community/john-git-conventional/profiles.toml
+```
+
+### 6. README bearbeiten
+
+Öffne `community/john-git-conventional/README.md` und fülle das Frontmatter aus:
+
+```yaml
+---
+author: john
+description: Git-Aliase für konventionelle Commit-Workflows
+category: git
+tags: [git, conventional-commits, workflow]
+profiles: [git, git-conventional]
+---
+```
+
+Schreibe dann ein paar Sätze darüber, was deine Aliase tun, wie du sie verwendest und welche Tools installiert sein müssen.
+
+::: details Frontmatter-Referenz
+| Feld | Pflichtfeld | Beschreibung |
+|------|-------------|--------------|
+| `author` | ja | Dein GitHub-Nutzername |
+| `description` | ja | Einzeilige Zusammenfassung (wird auf der Kachel angezeigt) |
+| `category` | ja | Eines von: `git`, `docker`, `rust`, `k8s`, `python`, `node`, `misc` |
+| `tags` | ja | Array von Stichwörtern für die Filterung |
+| `profiles` | ja | Profilnamen in deiner `profiles.toml` |
+| `shell` | nein | Nur setzen, wenn deine Aliase shell-spezifische Syntax verwenden (z. B. `fish`) |
+:::
+
+### 7. Testen
+
+Stelle sicher, dass der Import funktioniert:
+
+```bash
+cat community/john-git-conventional/profiles.toml | am import --yes
+```
+
+### 8. Committen und pushen
+
+```bash
+git add community/john-git-conventional/
+git commit -m "community: add john-git-conventional"
+git push origin community/john-git-conventional
+```
+
+### 9. Pull Request öffnen
+
+Gehe zu deinem Fork auf GitHub — du siehst ein Banner zum Erstellen eines Pull Requests. Klicke darauf und wähle die **Community Profile** PR-Vorlage.
+
+Die Checkliste führt dich durch das Notwendige:
+
+- [ ] Ordner mit dem Namen `community/john-git-conventional/`
+- [ ] `profiles.toml` ist eine gültige `am export`-Ausgabe
+- [ ] `README.md` hat das erforderliche Frontmatter
+- [ ] Nur Dateien in deinem eigenen Ordner wurden geändert
+- [ ] Import lokal getestet
+
+Dein Beitrag erscheint nach der Überprüfung im Showcase.
+
+## Regeln
+
+- Füge nur Dateien in deinem eigenen Ordner hinzu oder ändere sie
+- Ein Ordner pro Alias-Sammlung (mehrere Profile in einer `profiles.toml` sind in Ordnung)
+- Für eine zweite Sammlung erstelle einen zweiten Ordner (z. B. `john-docker-compose`)
+
+## Was macht einen guten Beitrag aus?
+
+- **Nützlich für andere** — Aliase, die häufige Workflows lösen
+- **Gut dokumentiert** — erkläre, was jeder Alias tut
+- **In sich geschlossen** — weise auf Abhängigkeiten hin
+- **Getestet** — überprüfe, dass der Import funktioniert
+
+::: warning Sicherheit
+Alle Einsendungen werden vor dem Zusammenführen geprüft. Wir prüfen auf verdächtige Inhalte, aber du solltest Aliase immer selbst inspizieren, bevor du sie importierst — auch aus diesem Showcase.
+:::

--- a/website/de/showcase/index.md
+++ b/website/de/showcase/index.md
@@ -1,7 +1,15 @@
-# Showcase
+<script setup>
+import { data } from '../../showcase/community.data'
+</script>
 
-::: tip Kommt bald
-Der Showcase wird community-erstellte Profile präsentieren, die du durchsuchen und in dein Setup importieren kannst.
+# Community Showcase <VersionBadge v="0.4.0" />
+
+Stöbere in Alias-Profilen, die von der Community geteilt wurden. Entdecke nützliche Profile, schaue dir die Aliase an und importiere sie mit einem einzigen Befehl.
+
+Wenn du den Import-Befehl ausführst, zeigt `am` eine Zusammenfassung aller Aliase, bevor etwas übernommen wird — überprüfe sie sorgfältig, bevor du bestätigst.
+
+<CommunityGallery :profiles="data" />
+
+::: tip Möchtest du deine eigenen Profile teilen?
+Schau in den [Beitragsleitfaden](./contribute), um zu erfahren, wie du deine einreichst.
 :::
-
-Hast du eine Profil-Sammlung, die du teilen möchtest? Bleib dran — die Import-Funktion ist in Entwicklung.


### PR DESCRIPTION
- Replace stale "Kommt bald" placeholder in `de/showcase/index.md` with the full `CommunityGallery` component, matching the English page
- Add `de/showcase/contribute.md` — German translation of the contribution guide (was missing entirely)
- Add `/de/showcase/` sidebar with German labels by parameterising `buildShowcaseSidebar()`
- Fix Google Search Console "Duplicate without user-selected canonical": VitePress sitemap was emitting `.html` URLs while `transformHead` emitted clean canonical tags — strip `.html` in `sitemap.transformItems` so both match