### PR TITLE
fix: hook reload local aliases when individual aliases changes

### DIFF
--- a/crates/am/src/env_vars.rs
+++ b/crates/am/src/env_vars.rs
@@ -2,8 +2,10 @@
 /// Value: comma-separated list, e.g. `"gs,ll"`.
 pub const AM_ALIASES: &str = "_AM_ALIASES";
 
-/// Tracks project-level alias names loaded by the cd hook.
-/// Value: comma-separated list, e.g. `"b,t"`.
+/// Tracks project-level aliases loaded by the cd hook.
+/// Value: comma-separated entries of `name|short_hash`, e.g. `"b|a132b21,t|1241ab1"`.
+/// The short hash is the first 7 hex chars of the BLAKE3 hash of the alias value,
+/// enabling per-alias change detection on reload.
 pub const AM_PROJECT_ALIASES: &str = "_AM_PROJECT_ALIASES";
 
 /// Path of the `.aliases` file currently in scope, used to suppress

--- a/crates/am/src/hook.rs
+++ b/crates/am/src/hook.rs
@@ -1,15 +1,41 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use crate::env_vars;
 use crate::project::ProjectAliases;
 use crate::security::{SecurityConfig, TrustStatus};
 use crate::shell::ShellContext;
-use crate::trust::{compute_file_hash, render_load_message, render_unload_message};
+use crate::trust::{compute_file_hash, compute_short_hash, render_load_message, render_unload_message};
+
+/// Parse `_AM_PROJECT_ALIASES` value: `"name|hash,name|hash,..."` into a map.
+/// Falls back to name-only format (no `|`) for backward compat during upgrade.
+fn parse_prev_aliases(raw: Option<&str>) -> BTreeMap<String, Option<String>> {
+    let mut map = BTreeMap::new();
+    let Some(s) = raw.filter(|s| !s.is_empty()) else {
+        return map;
+    };
+    for entry in s.split(',') {
+        if let Some((name, hash)) = entry.split_once('|') {
+            map.insert(name.to_string(), Some(hash.to_string()));
+        } else {
+            // Backward compat: name without hash — always triggers reload
+            map.insert(entry.to_string(), None);
+        }
+    }
+    map
+}
+
+/// Compute a short content hash for a regular alias.
+///
+/// Hashes the command string which determines the shell-visible behaviour.
+fn alias_content_hash(alias: &crate::alias::TomlAlias) -> String {
+    compute_short_hash(alias.command().as_bytes())
+}
 
 /// Generate shell code for the cd hook.
 ///
 /// `ctx.cwd` — the current working directory to search for `.aliases`.
-/// `previous_aliases` — comma-separated alias names from `_AM_PROJECT_ALIASES` env var.
+/// `previous_aliases` — comma-separated alias entries from `_AM_PROJECT_ALIASES` env var.
 pub fn generate_hook(ctx: &ShellContext, previous_aliases: Option<&str>) -> crate::Result<String> {
     let mut security = SecurityConfig::load().unwrap_or_default();
     let prev_project_path = std::env::var(env_vars::AM_PROJECT_PATH).ok();
@@ -50,10 +76,7 @@ pub fn generate_hook_with_security(
     let mut lines: Vec<String> = Vec::new();
     let mut security_changed = false;
 
-    let prev: Vec<&str> = previous_aliases
-        .filter(|s| !s.is_empty())
-        .map(|s| s.split(',').collect())
-        .unwrap_or_default();
+    let prev = parse_prev_aliases(previous_aliases);
 
     // `prev_project_path` tracks which .aliases file was last seen, to avoid
     // repeating warnings. It is passed in explicitly rather than read from the
@@ -61,11 +84,14 @@ pub fn generate_hook_with_security(
 
     // Helper: unalias only shell-level names (no `:` — subcommand keys like `c:l`
     // are tracked for change detection but are not themselves shell functions).
+    let unload_prev_names: Vec<String> = prev
+        .keys()
+        .filter(|n| !n.contains(':'))
+        .cloned()
+        .collect();
     let unload_prev = |lines: &mut Vec<String>| {
-        for name in &prev {
-            if !name.contains(':') {
-                lines.push(shell_impl.unalias(name));
-            }
+        for name in &unload_prev_names {
+            lines.push(shell_impl.unalias(name));
         }
     };
 
@@ -88,72 +114,181 @@ pub fn generate_hook_with_security(
                 TrustStatus::Trusted => {
                     let project = ProjectAliases::load(&path)?;
                     if !project.aliases.is_empty() || !project.subcommands.is_empty() {
-                        let names: Vec<String> = project
-                            .aliases
-                            .iter()
-                            .map(|(n, _)| n.as_ref().to_string())
-                            .collect();
-
                         let subcmd_groups =
                             crate::subcommand::group_by_program(&project.subcommands);
-
-                        // all_names tracks both the shell-level wrapper names (e.g. `c`) and
-                        // the individual subcommand keys (e.g. `c:l`, `c:t`). Wrapper names
-                        // are used to unload old functions; subcommand keys make change
-                        // detection precise — adding c:t when c:l already exists would
-                        // otherwise appear identical (both produce program name `c`).
                         let subcmd_program_names: Vec<String> =
                             subcmd_groups.keys().cloned().collect();
-                        let subcmd_keys: Vec<String> =
-                            project.subcommands.keys().cloned().collect();
 
-                        let mut all_names: Vec<String> = names.clone();
-                        all_names.extend(subcmd_program_names.clone());
-                        all_names.extend(subcmd_keys);
-                        all_names.sort();
-                        all_names.dedup();
+                        // Build current alias map: name -> short content hash
+                        let mut current: BTreeMap<String, String> = BTreeMap::new();
 
-                        // If the exact same set of aliases and subcommand keys is already
-                        // loaded, skip entirely — nothing changed.
-                        if all_names.len() == prev.len()
-                            && all_names.iter().zip(&prev).all(|(a, b)| a == b)
-                        {
+                        for (alias_name, alias_value) in project.aliases.iter() {
+                            current.insert(
+                                alias_name.as_ref().to_string(),
+                                alias_content_hash(alias_value),
+                            );
+                        }
+
+                        // Subcommand program names (shell-level wrapper function)
+                        for program in &subcmd_program_names {
+                            let entries_str: String = project
+                                .subcommands
+                                .iter()
+                                .filter(|(k, _)| k.starts_with(&format!("{program}:")))
+                                .map(|(k, v)| format!("{k}={}", v.join(",")))
+                                .collect::<Vec<_>>()
+                                .join(";");
+                            current.insert(
+                                program.clone(),
+                                compute_short_hash(entries_str.as_bytes()),
+                            );
+                        }
+
+                        // Individual subcommand keys for fine-grained tracking
+                        for (key, longs) in project.subcommands.iter() {
+                            current.insert(
+                                key.clone(),
+                                compute_short_hash(longs.join(",").as_bytes()),
+                            );
+                        }
+
+                        // Compute diff against previous state
+                        let mut removed: Vec<String> = Vec::new();
+                        let mut added: Vec<String> = Vec::new();
+                        let mut changed: Vec<String> = Vec::new();
+
+                        for name in prev.keys() {
+                            if !current.contains_key(name) {
+                                removed.push(name.clone());
+                            }
+                        }
+                        for (name, hash) in &current {
+                            match prev.get(name) {
+                                None => added.push(name.clone()),
+                                Some(prev_hash) => {
+                                    // If prev had no hash (backward compat) or hash
+                                    // differs -> changed
+                                    if prev_hash.as_deref() != Some(hash.as_str()) {
+                                        changed.push(name.clone());
+                                    }
+                                }
+                            }
+                        }
+
+                        // If nothing changed at all, skip entirely
+                        if removed.is_empty() && added.is_empty() && changed.is_empty() {
                             return Ok((String::new(), false));
                         }
 
-                        unload_prev(&mut lines);
+                        let is_fresh_load = prev.is_empty();
 
-                        if show_messages {
-                            for line in
-                                render_load_message(&project.aliases, &project.subcommands).lines()
-                            {
-                                lines.push(shell_impl.echo(line));
+                        // 1. Unload removed + changed (not unchanged!)
+                        for name in removed.iter().chain(changed.iter()) {
+                            if !name.contains(':') {
+                                lines.push(shell_impl.unalias(name));
                             }
                         }
 
-                        // Emit regular aliases (skip those with subcommand wrappers)
+                        // 2. Show messages
+                        if show_messages {
+                            if is_fresh_load {
+                                // Full load message (same as cd-into-project)
+                                for line in render_load_message(
+                                    &project.aliases,
+                                    &project.subcommands,
+                                )
+                                .lines()
+                                {
+                                    lines.push(shell_impl.echo(line));
+                                }
+                            } else {
+                                // Incremental change summary
+                                let mut parts = Vec::new();
+                                if !added.is_empty() {
+                                    parts.push(format!("{} added", added.len()));
+                                }
+                                if !changed.is_empty() {
+                                    parts.push(format!("{} updated", changed.len()));
+                                }
+                                if !removed.is_empty() {
+                                    parts.push(format!("{} removed", removed.len()));
+                                }
+                                lines.push(shell_impl.echo(&format!(
+                                    "am: .aliases changed ({})",
+                                    parts.join(", ")
+                                )));
+                            }
+                        }
+
                         let programs_set: std::collections::BTreeSet<&str> =
                             subcmd_groups.keys().map(|s| s.as_str()).collect();
-                        for (alias_name, alias_value) in project.aliases.iter() {
-                            let name = alias_name.as_ref();
-                            if !programs_set.contains(name) {
-                                lines.push(shell_impl.alias(&alias_value.as_entry(name)));
+
+                        if is_fresh_load {
+                            // 3a. Fresh load: emit all aliases
+                            for (alias_name, alias_value) in project.aliases.iter() {
+                                let name = alias_name.as_ref();
+                                if !programs_set.contains(name) {
+                                    lines.push(shell_impl.alias(&alias_value.as_entry(name)));
+                                }
+                            }
+
+                            // All subcommand wrappers
+                            for (program, entries) in &subcmd_groups {
+                                let base_cmd = project
+                                    .aliases
+                                    .iter()
+                                    .find(|(n, _)| n.as_ref() == program.as_str())
+                                    .map(|(_, v)| v.command().to_string())
+                                    .unwrap_or_else(|| format!("command {program}"));
+                                lines.push(
+                                    shell_impl.subcommand_wrapper(program, &base_cmd, entries),
+                                );
+                            }
+                        } else {
+                            // 3b. Incremental: only load added + changed aliases
+                            for (alias_name, alias_value) in project.aliases.iter() {
+                                let name = alias_name.as_ref();
+                                if !programs_set.contains(name)
+                                    && (added.contains(&name.to_string())
+                                        || changed.contains(&name.to_string()))
+                                {
+                                    lines.push(shell_impl.alias(&alias_value.as_entry(name)));
+                                }
+                            }
+
+                            // Reload subcommand wrappers if any subcmd was
+                            // added/changed/removed
+                            let subcmd_changed = added
+                                .iter()
+                                .chain(changed.iter())
+                                .chain(removed.iter())
+                                .any(|n| {
+                                    n.contains(':') || subcmd_program_names.contains(n)
+                                });
+                            if subcmd_changed {
+                                for (program, entries) in &subcmd_groups {
+                                    let base_cmd = project
+                                        .aliases
+                                        .iter()
+                                        .find(|(n, _)| n.as_ref() == program.as_str())
+                                        .map(|(_, v)| v.command().to_string())
+                                        .unwrap_or_else(|| format!("command {program}"));
+                                    lines.push(
+                                        shell_impl
+                                            .subcommand_wrapper(program, &base_cmd, entries),
+                                    );
+                                }
                             }
                         }
 
-                        // Emit subcommand wrappers
-                        for (program, entries) in &subcmd_groups {
-                            let base_cmd = project
-                                .aliases
-                                .iter()
-                                .find(|(n, _)| n.as_ref() == program.as_str())
-                                .map(|(_, v)| v.command().to_string())
-                                .unwrap_or_else(|| format!("command {program}"));
-                            lines.push(shell_impl.subcommand_wrapper(program, &base_cmd, entries));
-                        }
-
+                        // 4. Update tracking env var with name|hash format
+                        let tracking: Vec<String> = current
+                            .iter()
+                            .map(|(name, hash)| format!("{name}|{hash}"))
+                            .collect();
                         lines.push(
-                            shell_impl.set_env(env_vars::AM_PROJECT_ALIASES, &all_names.join(",")),
+                            shell_impl
+                                .set_env(env_vars::AM_PROJECT_ALIASES, &tracking.join(",")),
                         );
                     }
                 }
@@ -196,7 +331,8 @@ pub fn generate_hook_with_security(
             if !prev.is_empty() {
                 unload_prev(&mut lines);
                 if !quiet {
-                    lines.push(shell_impl.echo(&render_unload_message(&prev)));
+                    let prev_names: Vec<&str> = unload_prev_names.iter().map(|s| s.as_str()).collect();
+                    lines.push(shell_impl.echo(&render_unload_message(&prev_names)));
                 }
                 lines.push(shell_impl.unset_env(env_vars::AM_PROJECT_ALIASES));
             }
@@ -213,7 +349,23 @@ pub fn generate_hook_with_security(
 mod tests {
     use super::*;
     use crate::shell::Shell;
+    use crate::trust::compute_short_hash;
     use std::path::{Path, PathBuf};
+
+    /// Extract the `_AM_PROJECT_ALIASES` value from generated shell code.
+    fn extract_prev_aliases(output: &str, shell: &Shell) -> Option<String> {
+        let prefix = match shell {
+            Shell::Fish => "set -gx _AM_PROJECT_ALIASES \"",
+            _ => "export _AM_PROJECT_ALIASES=\"",
+        };
+        output.lines()
+            .find(|l| l.contains("_AM_PROJECT_ALIASES"))
+            .and_then(|l| {
+                let start = l.find(prefix).map(|i| i + prefix.len())?;
+                let end = l[start..].find('"').map(|i| start + i)?;
+                Some(l[start..end].to_string())
+            })
+    }
 
     /// Builder for hook test fixtures.
     struct TestBed {
@@ -366,7 +518,11 @@ mod tests {
         assert!(output.contains("functions -e old1"));
         assert!(output.contains("functions -e old2"));
         assert!(output.contains("alias new1 \"echo new\""));
-        assert!(output.contains("\"new1\""));
+        let new1_hash = compute_short_hash(b"echo new");
+        assert!(
+            output.contains(&format!("\"new1|{new1_hash}\"")),
+            "expected new1|hash in env var, got: {output}"
+        );
     }
 
     #[test]
@@ -395,13 +551,30 @@ mod tests {
         assert!(output.contains("alias b \"make build\""));
         assert!(!output.contains("alias t"));
 
+        // Extract prev from first run to feed back as realistic input
+        let prev = extract_prev_aliases(&output, &Shell::Fish);
+
         t.update_aliases("[aliases]\nb = \"make build\"\nt = \"make test\"\n");
 
-        let (output, _) = t.run(&Shell::Fish, &cwd, Some("b"));
-        assert!(output.contains("functions -e b"));
-        assert!(output.contains("alias b \"make build\""));
+        let (output, _) = t.run(&Shell::Fish, &cwd, prev.as_deref());
+        // b is unchanged so should NOT be unloaded or reloaded
+        assert!(
+            !output.contains("functions -e b"),
+            "unchanged alias b should not be unloaded, got: {output}"
+        );
+        assert!(
+            !output.contains("alias b \"make build\""),
+            "unchanged alias b should not be reloaded, got: {output}"
+        );
+        // t is newly added
         assert!(output.contains("alias t \"make test\""));
-        assert!(output.contains("\"b,t\""));
+        // Env var now contains both with hashes
+        let b_hash = compute_short_hash(b"make build");
+        let t_hash = compute_short_hash(b"make test");
+        assert!(
+            output.contains(&format!("b|{b_hash},t|{t_hash}")),
+            "expected b|hash,t|hash in env var, got: {output}"
+        );
     }
 
     #[test]
@@ -416,14 +589,33 @@ mod tests {
         assert!(output.contains("alias b"));
         assert!(output.contains("alias t"));
 
+        // Extract prev from first run
+        let prev = extract_prev_aliases(&output, &Shell::Fish);
+
         t.update_aliases("[aliases]\nb = \"make build\"\n");
 
-        let (output, _) = t.run(&Shell::Fish, &cwd, Some("b,t"));
-        assert!(output.contains("functions -e b"));
-        assert!(output.contains("functions -e t"));
-        assert!(output.contains("alias b \"make build\""));
+        let (output, _) = t.run(&Shell::Fish, &cwd, prev.as_deref());
+        // b is unchanged: should NOT be unloaded or reloaded
+        assert!(
+            !output.contains("functions -e b"),
+            "unchanged alias b should not be unloaded, got: {output}"
+        );
+        assert!(
+            !output.contains("alias b \"make build\""),
+            "unchanged alias b should not be reloaded, got: {output}"
+        );
+        // t is removed: should be unloaded
+        assert!(
+            output.contains("functions -e t"),
+            "removed alias t should be unloaded, got: {output}"
+        );
         assert!(!output.contains("alias t \"make test\""));
-        assert!(output.contains("\"b\""));
+        // Env var only contains b now
+        let b_hash = compute_short_hash(b"make build");
+        assert!(
+            output.contains(&format!("\"b|{b_hash}\"")),
+            "expected b|hash in env var, got: {output}"
+        );
     }
 
     #[test]
@@ -582,11 +774,14 @@ mod tests {
         );
         assert!(output.contains("clippy"));
 
+        // Extract prev from first run for realistic change detection
+        let prev = extract_prev_aliases(&output, &Shell::Fish);
+
         // Add c:t — the .aliases file changes, but program name `c` stays the same
         t.update_aliases("[subcommands]\n\"c:l\" = [\"clippy\"]\n\"c:t\" = [\"test\"]\n");
 
-        // Second run: prev="c" (already loaded), but file has new content
-        let (output, _) = t.run(&Shell::Fish, &cwd, Some("c"));
+        // Second run: prev has c|hash and c:l|hash, but file has new content
+        let (output, _) = t.run(&Shell::Fish, &cwd, prev.as_deref());
         assert!(
             output.contains("function c"),
             "hook must re-emit c wrapper after new subcommand added, got: {output}"
@@ -612,5 +807,165 @@ mod tests {
         assert!(output.contains("alias b=\"make build\""));
         assert!(output.contains("jj() {"));
         assert!(output.contains("ab) shift; command jj abandon"));
+    }
+
+    // ─── Per-alias content hashing ─────────────────────────────────
+
+    #[test]
+    fn test_parse_prev_aliases_new_format() {
+        let map = parse_prev_aliases(Some("b|abc1234,t|def5678"));
+        assert_eq!(map.len(), 2);
+        assert_eq!(map["b"], Some("abc1234".to_string()));
+        assert_eq!(map["t"], Some("def5678".to_string()));
+    }
+
+    #[test]
+    fn test_parse_prev_aliases_old_format_backward_compat() {
+        let map = parse_prev_aliases(Some("b,t"));
+        assert_eq!(map.len(), 2);
+        assert_eq!(map["b"], None);
+        assert_eq!(map["t"], None);
+    }
+
+    #[test]
+    fn test_parse_prev_aliases_empty() {
+        assert!(parse_prev_aliases(None).is_empty());
+        assert!(parse_prev_aliases(Some("")).is_empty());
+    }
+
+    #[test]
+    fn test_parse_prev_aliases_mixed_format() {
+        let map = parse_prev_aliases(Some("b|abc1234,t,gs|fed9876"));
+        assert_eq!(map.len(), 3);
+        assert_eq!(map["b"], Some("abc1234".to_string()));
+        assert_eq!(map["t"], None);
+        assert_eq!(map["gs"], Some("fed9876".to_string()));
+    }
+
+    #[test]
+    fn test_alias_content_hash_deterministic() {
+        let alias = crate::TomlAlias::Command("make build".to_string());
+        let h1 = alias_content_hash(&alias);
+        let h2 = alias_content_hash(&alias);
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 7);
+    }
+
+    #[test]
+    fn test_alias_content_hash_different_commands() {
+        let a = crate::TomlAlias::Command("make build".to_string());
+        let b = crate::TomlAlias::Command("cargo build".to_string());
+        assert_ne!(alias_content_hash(&a), alias_content_hash(&b));
+    }
+
+    #[test]
+    fn test_hook_reloads_when_alias_value_changes() {
+        let mut t = TestBed::new()
+            .with_aliases("[aliases]\nb = \"make build\"\n")
+            .with_security_trusted()
+            .setup();
+
+        let cwd = t.root();
+        let (output, _) = t.run(&Shell::Fish, &cwd, None);
+        assert!(output.contains("alias b \"make build\""));
+
+        // Extract prev from first run
+        let prev = extract_prev_aliases(&output, &Shell::Fish);
+
+        // Update alias value (same name, different command) and re-trust
+        t.update_aliases("[aliases]\nb = \"cargo build\"\n");
+
+        // Hook with prev — same name "b" but different command
+        let (output, _) = t.run(&Shell::Fish, &cwd, prev.as_deref());
+        assert!(
+            output.contains("alias b \"cargo build\""),
+            "hook must reload when alias value changes, got: {output}"
+        );
+        // Old value should be unloaded first
+        assert!(
+            output.contains("functions -e b"),
+            "changed alias should be unloaded before reload, got: {output}"
+        );
+    }
+
+    #[test]
+    fn test_hook_skips_unchanged_aliases() {
+        let mut t = TestBed::new()
+            .with_aliases("[aliases]\nb = \"make build\"\nt = \"make test\"\n")
+            .with_security_trusted()
+            .setup();
+
+        let cwd = t.root();
+        let (output, _) = t.run(&Shell::Fish, &cwd, None);
+
+        // Extract prev from first run
+        let prev = extract_prev_aliases(&output, &Shell::Fish);
+
+        // Re-run with same content — should skip entirely
+        let (output, _) = t.run(&Shell::Fish, &cwd, prev.as_deref());
+        assert!(
+            output.is_empty(),
+            "unchanged aliases should produce no output, got: {output}"
+        );
+    }
+
+    #[test]
+    fn test_hook_incremental_message_on_change() {
+        let mut t = TestBed::new()
+            .with_aliases("[aliases]\nb = \"make build\"\nt = \"make test\"\n")
+            .with_security_trusted()
+            .setup();
+
+        let cwd = t.root();
+        let (output, _) = t.run(&Shell::Fish, &cwd, None);
+        // Fresh load shows full message
+        assert!(output.contains("am: loaded .aliases"));
+
+        let prev = extract_prev_aliases(&output, &Shell::Fish);
+
+        // Change t, add x, remove nothing
+        t.update_aliases("[aliases]\nb = \"make build\"\nt = \"make test --all\"\nx = \"exit\"\n");
+
+        let (output, _) = t.run(&Shell::Fish, &cwd, prev.as_deref());
+        // Incremental message instead of full load
+        assert!(
+            output.contains("am: .aliases changed"),
+            "should show incremental change message, got: {output}"
+        );
+        assert!(
+            !output.contains("am: loaded .aliases"),
+            "should not show full load message on incremental change, got: {output}"
+        );
+    }
+
+    #[test]
+    fn test_hook_backward_compat_old_format_triggers_full_reload() {
+        let mut t = TestBed::new()
+            .with_aliases("[aliases]\nb = \"make build\"\n")
+            .with_security_trusted()
+            .setup();
+
+        let cwd = t.root();
+        // Old format: no hashes
+        let (output, _) = t.run(&Shell::Fish, &cwd, Some("b"));
+        // Should treat b as "changed" (prev hash is None) and reload
+        assert!(
+            output.contains("alias b \"make build\""),
+            "backward compat: old format should trigger reload, got: {output}"
+        );
+    }
+
+    #[test]
+    fn test_extract_prev_aliases_fish() {
+        let output = "set -gx _AM_PROJECT_ALIASES \"b|abc1234,t|def5678\"";
+        let prev = extract_prev_aliases(output, &Shell::Fish);
+        assert_eq!(prev, Some("b|abc1234,t|def5678".to_string()));
+    }
+
+    #[test]
+    fn test_extract_prev_aliases_bash() {
+        let output = "export _AM_PROJECT_ALIASES=\"b|abc1234,t|def5678\"";
+        let prev = extract_prev_aliases(output, &Shell::Bash);
+        assert_eq!(prev, Some("b|abc1234,t|def5678".to_string()));
     }
 }

--- a/crates/am/src/hook.rs
+++ b/crates/am/src/hook.rs
@@ -5,7 +5,9 @@ use crate::env_vars;
 use crate::project::ProjectAliases;
 use crate::security::{SecurityConfig, TrustStatus};
 use crate::shell::ShellContext;
-use crate::trust::{compute_file_hash, compute_short_hash, render_load_message, render_unload_message};
+use crate::trust::{
+    compute_file_hash, compute_short_hash, render_load_message, render_unload_message,
+};
 
 /// Parse `_AM_PROJECT_ALIASES` value: `"name|hash,name|hash,..."` into a map.
 /// Falls back to name-only format (no `|`) for backward compat during upgrade.
@@ -84,11 +86,8 @@ pub fn generate_hook_with_security(
 
     // Helper: unalias only shell-level names (no `:` — subcommand keys like `c:l`
     // are tracked for change detection but are not themselves shell functions).
-    let unload_prev_names: Vec<String> = prev
-        .keys()
-        .filter(|n| !n.contains(':'))
-        .cloned()
-        .collect();
+    let unload_prev_names: Vec<String> =
+        prev.keys().filter(|n| !n.contains(':')).cloned().collect();
     let unload_prev = |lines: &mut Vec<String>| {
         for name in &unload_prev_names {
             lines.push(shell_impl.unalias(name));
@@ -193,11 +192,9 @@ pub fn generate_hook_with_security(
                         if show_messages {
                             if is_fresh_load {
                                 // Full load message (same as cd-into-project)
-                                for line in render_load_message(
-                                    &project.aliases,
-                                    &project.subcommands,
-                                )
-                                .lines()
+                                for line in
+                                    render_load_message(&project.aliases, &project.subcommands)
+                                        .lines()
                                 {
                                     lines.push(shell_impl.echo(line));
                                 }
@@ -213,10 +210,12 @@ pub fn generate_hook_with_security(
                                 if !removed.is_empty() {
                                     parts.push(format!("{} removed", removed.len()));
                                 }
-                                lines.push(shell_impl.echo(&format!(
-                                    "am: .aliases changed ({})",
-                                    parts.join(", ")
-                                )));
+                                lines.push(
+                                    shell_impl.echo(&format!(
+                                        "am: .aliases changed ({})",
+                                        parts.join(", ")
+                                    )),
+                                );
                             }
                         }
 
@@ -262,9 +261,7 @@ pub fn generate_hook_with_security(
                                 .iter()
                                 .chain(changed.iter())
                                 .chain(removed.iter())
-                                .any(|n| {
-                                    n.contains(':') || subcmd_program_names.contains(n)
-                                });
+                                .any(|n| n.contains(':') || subcmd_program_names.contains(n));
                             if subcmd_changed {
                                 for (program, entries) in &subcmd_groups {
                                     let base_cmd = project
@@ -274,8 +271,7 @@ pub fn generate_hook_with_security(
                                         .map(|(_, v)| v.command().to_string())
                                         .unwrap_or_else(|| format!("command {program}"));
                                     lines.push(
-                                        shell_impl
-                                            .subcommand_wrapper(program, &base_cmd, entries),
+                                        shell_impl.subcommand_wrapper(program, &base_cmd, entries),
                                     );
                                 }
                             }
@@ -287,8 +283,7 @@ pub fn generate_hook_with_security(
                             .map(|(name, hash)| format!("{name}|{hash}"))
                             .collect();
                         lines.push(
-                            shell_impl
-                                .set_env(env_vars::AM_PROJECT_ALIASES, &tracking.join(",")),
+                            shell_impl.set_env(env_vars::AM_PROJECT_ALIASES, &tracking.join(",")),
                         );
                     }
                 }
@@ -331,7 +326,8 @@ pub fn generate_hook_with_security(
             if !prev.is_empty() {
                 unload_prev(&mut lines);
                 if !quiet {
-                    let prev_names: Vec<&str> = unload_prev_names.iter().map(|s| s.as_str()).collect();
+                    let prev_names: Vec<&str> =
+                        unload_prev_names.iter().map(|s| s.as_str()).collect();
                     lines.push(shell_impl.echo(&render_unload_message(&prev_names)));
                 }
                 lines.push(shell_impl.unset_env(env_vars::AM_PROJECT_ALIASES));
@@ -358,7 +354,8 @@ mod tests {
             Shell::Fish => "set -gx _AM_PROJECT_ALIASES \"",
             _ => "export _AM_PROJECT_ALIASES=\"",
         };
-        output.lines()
+        output
+            .lines()
             .find(|l| l.contains("_AM_PROJECT_ALIASES"))
             .and_then(|l| {
                 let start = l.find(prefix).map(|i| i + prefix.len())?;

--- a/crates/am/src/trust.rs
+++ b/crates/am/src/trust.rs
@@ -47,6 +47,14 @@ pub fn compute_hash(content: &[u8]) -> String {
     blake3::hash(content).to_hex().to_string()
 }
 
+/// Compute a 7-character short BLAKE3 hash of byte content.
+///
+/// Returns the first 7 hex characters of the BLAKE3 hash — analogous to
+/// git's short SHA. 28 bits gives collision probability <0.2 % for 1 000 items.
+pub fn compute_short_hash(content: &[u8]) -> String {
+    blake3::hash(content).to_hex()[..7].to_string()
+}
+
 /// Render the "loaded" info message shown on cd into a trusted directory.
 ///
 /// Alias names are right-padded so `->` and commands align in columns.
@@ -116,6 +124,27 @@ mod tests {
         let hash1 = compute_hash(b"[aliases]\nb = \"make build\"\n");
         let hash2 = compute_hash(b"[aliases]\nb = \"make build\"\n");
         assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn compute_short_hash_returns_7_chars() {
+        let hash = compute_short_hash(b"make build");
+        assert_eq!(hash.len(), 7);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn compute_short_hash_deterministic() {
+        let h1 = compute_short_hash(b"make build");
+        let h2 = compute_short_hash(b"make build");
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn compute_short_hash_different_content() {
+        let h1 = compute_short_hash(b"make build");
+        let h2 = compute_short_hash(b"cargo build");
+        assert_ne!(h1, h2);
     }
 
     #[test]

--- a/crates/am/tests/snapshots/snapshots__snapshot_hook_bash_with_aliases.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_hook_bash_with_aliases.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 584
 expression: output
 ---
 printf '%s\n' 'am: loaded .aliases'
@@ -7,4 +8,4 @@ printf '%s\n' '  b → cargo build'
 printf '%s\n' '  t → cargo test'
 alias b="cargo build"
 alias t="cargo test"
-export _AM_PROJECT_ALIASES="b,t"
+export _AM_PROJECT_ALIASES="b|b58de66,t|ab61de4"

--- a/crates/am/tests/snapshots/snapshots__snapshot_hook_fish_transition.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_hook_fish_transition.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 613
 expression: output
 ---
 functions -e old_a
 functions -e old_b
-echo 'am: loaded .aliases'
-echo '  t → make test'
+echo 'am: .aliases changed (1 added, 2 removed)'
 alias t "make test"
-set -gx _AM_PROJECT_ALIASES "t"
+set -gx _AM_PROJECT_ALIASES "t|7f7c42c"

--- a/crates/am/tests/snapshots/snapshots__snapshot_hook_fish_with_aliases.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_hook_fish_with_aliases.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 497
 expression: output
 ---
 echo 'am: loaded .aliases'
@@ -7,4 +8,4 @@ echo '  b → cargo build'
 echo '  t → cargo test'
 alias b "cargo build"
 alias t "cargo test"
-set -gx _AM_PROJECT_ALIASES "b,t"
+set -gx _AM_PROJECT_ALIASES "b|b58de66,t|ab61de4"

--- a/crates/am/tests/snapshots/snapshots__snapshot_hook_powershell_with_aliases.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_hook_powershell_with_aliases.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 555
 expression: output
 ---
 Write-Host 'am: loaded .aliases'
@@ -7,4 +8,4 @@ Write-Host '  b → cargo build'
 Write-Host '  t → cargo test'
 function global:b { cargo build @args }
 function global:t { cargo test @args }
-$env:_AM_PROJECT_ALIASES = "b,t"
+$env:_AM_PROJECT_ALIASES = "b|b58de66,t|ab61de4"

--- a/crates/am/tests/snapshots/snapshots__snapshot_hook_zsh_with_aliases.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_hook_zsh_with_aliases.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 526
 expression: output
 ---
 printf '%s\n' 'am: loaded .aliases'
@@ -7,4 +8,4 @@ printf '%s\n' '  b → cargo build'
 printf '%s\n' '  t → cargo test'
 alias b="cargo build"
 alias t="cargo test"
-export _AM_PROJECT_ALIASES="b,t"
+export _AM_PROJECT_ALIASES="b|b58de66,t|ab61de4"


### PR DESCRIPTION
## Summary

- The cd hook compared only alias **name sets** to skip reload — overwriting an existing local alias (`am add -l t "new cmd"`) was silently ignored because the name didn't change
- Replace name-only comparison with per-alias 7-char blake3 content hashes stored in `_AM_PROJECT_ALIASES` (`name|shorthash,...`)
- Hook now diffs at the individual alias level: added / removed / changed / unchanged — only unloads+reloads what actually changed
- Fresh `cd`-in still shows the full alias listing; incremental changes show a compact summary (`am: .aliases changed (1 updated)`)
- Backward compatible with old `name,name,...` format (entries without hash always trigger reload)
- Closes #105