### PR TITLE
fix: apply_import was overwriting the user's real config on every cargo test

### DIFF
--- a/crates/am/src/bin/am.rs
+++ b/crates/am/src/bin/am.rs
@@ -176,7 +176,7 @@ fn main() -> anyhow::Result<()> {
             };
             let result = update(&mut model, msg)?;
             execute_effects(&mut model, &result.effects)?;
-            model.config.save()?;
+            model.save_config()?;
             return Ok(());
         }
         Commands::Profile { action } => match action
@@ -186,7 +186,7 @@ fn main() -> anyhow::Result<()> {
             ProfileAction::Add { name } => {
                 let result = update(&mut model, Message::CreateProfile(name.clone()))?;
                 execute_effects(&mut model, &result.effects)?;
-                model.config.save()?;
+                model.save_config()?;
                 return Ok(());
             }
             ProfileAction::Use {
@@ -205,7 +205,7 @@ fn main() -> anyhow::Result<()> {
                 };
                 let result = update(&mut model, msg)?;
                 execute_effects(&mut model, &result.effects)?;
-                model.config.save()?;
+                model.save_config()?;
                 return Ok(());
             }
             ProfileAction::Remove { name, force } => {
@@ -242,7 +242,7 @@ fn main() -> anyhow::Result<()> {
                 }
                 let result = update(&mut model, Message::RemoveProfile(name.clone()))?;
                 execute_effects(&mut model, &result.effects)?;
-                model.config.save()?;
+                model.save_config()?;
                 return Ok(());
             }
             ProfileAction::List { used } => Message::ListProfiles { used: *used },
@@ -408,9 +408,9 @@ fn execute_effects(model: &mut AppModel, effects: &[Effect]) -> anyhow::Result<(
 
     for effect in effects {
         match effect {
-            Effect::SaveConfig => model.config.save()?,
-            Effect::SaveSession => model.session.save()?,
-            Effect::SaveProfiles => model.profile_config().save()?,
+            Effect::SaveConfig => model.save_config()?,
+            Effect::SaveSession => model.save_session()?,
+            Effect::SaveProfiles => model.save_profiles()?,
             Effect::AddLocalAlias { name, cmd, raw } => add_local_alias(name, cmd, *raw)?,
             Effect::RemoveLocalAlias { name } => remove_local_alias(name)?,
             Effect::AddLocalSubcommand {
@@ -419,7 +419,7 @@ fn execute_effects(model: &mut AppModel, effects: &[Effect]) -> anyhow::Result<(
             } => add_local_subcommand(key, long_subcommands)?,
             Effect::RemoveLocalSubcommand { key } => remove_local_subcommand(key)?,
             Effect::Print(text) => println!("{text}"),
-            Effect::SaveSecurity => model.security_config().save()?,
+            Effect::SaveSecurity => model.save_security()?,
         }
     }
 
@@ -429,7 +429,7 @@ fn execute_effects(model: &mut AppModel, effects: &[Effect]) -> anyhow::Result<(
             let path = path.to_path_buf();
             let new_hash = compute_file_hash(&path)?;
             model.security_config_mut().update_hash(&path, &new_hash);
-            model.security_config().save()?;
+            model.save_security()?;
         }
     }
 

--- a/crates/am/src/config.rs
+++ b/crates/am/src/config.rs
@@ -53,10 +53,6 @@ impl Config {
         Self::load_from(&crate::dirs::config_dir())
     }
 
-    pub fn save(&self) -> crate::Result<()> {
-        self.save_to(&crate::dirs::config_dir())
-    }
-
     pub fn add_alias(&mut self, name: String, command: String, raw: bool) {
         let key: AliasName = name.into();
         let alias = if raw {

--- a/crates/am/src/import_export.rs
+++ b/crates/am/src/import_export.rs
@@ -512,8 +512,8 @@ fn apply_import(model: &mut AppModel, payload: ImportPayload) -> anyhow::Result<
     // Execute effects (SaveConfig, SaveProfiles)
     for effect in &result.effects {
         match effect {
-            Effect::SaveConfig => model.config.save()?,
-            Effect::SaveProfiles => model.profile_config().save()?,
+            Effect::SaveConfig => model.save_config()?,
+            Effect::SaveProfiles => model.save_profiles()?,
             _ => {}
         }
     }
@@ -939,9 +939,10 @@ mod tests {
             ..Default::default()
         };
 
-        // apply_import calls update() + saves — config save will fail
-        // because there's no config dir, but the model mutation should work
-        let _ = apply_import(&mut model, payload);
-        assert_eq!(model.config.aliases.len(), 1);
+        // apply_import routes through AppModel::save_config, which is a no-op
+        // when config_dir is empty (set that way by AppModel::new). The model's
+        // in-memory config still receives the imported aliases.
+        apply_import(&mut model, payload).unwrap();
+        assert_eq!(model.config.aliases.iter().count(), 1);
     }
 }

--- a/crates/am/src/profile.rs
+++ b/crates/am/src/profile.rs
@@ -171,10 +171,6 @@ impl ProfileConfig {
         Ok(decoded)
     }
 
-    pub fn save(&self) -> Result<()> {
-        self.save_to(&config_dir())
-    }
-
     pub fn save_to(&self, config_dir: &std::path::Path) -> Result<()> {
         if !config_dir.exists() {
             std::fs::create_dir_all(config_dir)?;

--- a/crates/am/src/security.rs
+++ b/crates/am/src/security.rs
@@ -64,10 +64,6 @@ impl SecurityConfig {
         Self::load_from(&crate::dirs::config_dir())
     }
 
-    pub fn save(&self) -> crate::Result<()> {
-        self.save_to(&crate::dirs::config_dir())
-    }
-
     /// Check trust status for a given path and current file hash.
     /// If a trusted entry has a hash mismatch, transitions to tampered in-memory.
     pub fn check(&mut self, path: &Path, current_hash: &str) -> TrustStatus {

--- a/crates/am/src/session.rs
+++ b/crates/am/src/session.rs
@@ -35,10 +35,6 @@ impl Session {
         Self::load_from(&crate::dirs::config_dir())
     }
 
-    pub fn save(&self) -> crate::Result<()> {
-        self.save_to(&crate::dirs::config_dir())
-    }
-
     pub fn toggle_profile(&mut self, name: String) {
         if let Some(pos) = self.active_profiles.iter().position(|p| p == &name) {
             self.active_profiles.remove(pos);


### PR DESCRIPTION
## Why

- The argumentless `Config::save()` / `ProfileConfig::save()` helpers always write to `~/.config/amoxide/`, ignoring the `AppModel`'s `config_dir`. `apply_import` used them, so tests built with `AppModel::new(...)` (empty `config_dir`, no disk write intended) still overwrote the real config.
- Symptom: every `cargo test` reset `~/.config/amoxide/config.toml` to the single alias produced by `test_apply_import_global`, silently losing any global aliases added since the previous run.

## Fix

- Route `apply_import` and the CLI binary through the guarded `AppModel::save_*` methods that honour `config_dir`. No behaviour change for the binary (its `AppModel::default()` sets the real dir anyway); library unit tests are now correctly no-op on disk.
- Delete the argumentless `Config::save` / `Session::save` / `ProfileConfig::save` / `SecurityConfig::save` methods so the same footgun can't be reintroduced.

## Verify

- `cargo test --workspace` → 509 green, zero regressions.
- `stat -f "%m" ~/.config/amoxide/config.toml` before and after a workspace test run → mtime unchanged.