### PR TITLE
feat: add explicit enable/disable flags to am use

### DIFF
--- a/completions/bash/am.bash
+++ b/completions/bash/am.bash
@@ -707,7 +707,7 @@ _am() {
             return 0
             ;;
         am__subcmd__profile__subcmd__use)
-            opts="-n -i -h -V --priority --inverse --help --version [NAMES]..."
+            opts="-e -d -n -i -h -V --enable --disable --priority --inverse --help --version [NAMES]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -861,7 +861,7 @@ _am() {
             return 0
             ;;
         am__subcmd__use)
-            opts="-n -i -h -V --priority --inverse --help --version [NAMES]..."
+            opts="-e -d -n -i -h -V --enable --disable --priority --inverse --help --version [NAMES]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/fish/am.fish
+++ b/completions/fish/am.fish
@@ -70,6 +70,8 @@ complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subco
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s e -l enable -d 'Enable given profile(s), does not toggle'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s d -l disable -d 'Disable given profile(s), does not toggle'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s V -l version -d 'Print version'
@@ -90,6 +92,8 @@ complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print ve
 complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand setup" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand use" -s e -l enable -d 'Enable given profile(s), does not toggle'
+complete -c am -n "__fish_am_using_subcommand use" -s d -l disable -d 'Disable given profile(s), does not toggle'
 complete -c am -n "__fish_am_using_subcommand use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
 complete -c am -n "__fish_am_using_subcommand use" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand use" -s V -l version -d 'Print version'

--- a/completions/powershell/_am.ps1
+++ b/completions/powershell/_am.ps1
@@ -110,6 +110,10 @@ Register-ArgumentCompleter -Native -CommandName 'am' -ScriptBlock {
         'am;profile;use' {
             [CompletionResult]::new('-n', '-n', [CompletionResultType]::ParameterName, 'Activate at specific priority position (1-based). Repositions if already active')
             [CompletionResult]::new('--priority', '--priority', [CompletionResultType]::ParameterName, 'Activate at specific priority position (1-based). Repositions if already active')
+            [CompletionResult]::new('-e', '-e', [CompletionResultType]::ParameterName, 'Enable given profile(s), does not toggle')
+            [CompletionResult]::new('--enable', '--enable', [CompletionResultType]::ParameterName, 'Enable given profile(s), does not toggle')
+            [CompletionResult]::new('-d', '-d', [CompletionResultType]::ParameterName, 'Disable given profile(s), does not toggle')
+            [CompletionResult]::new('--disable', '--disable', [CompletionResultType]::ParameterName, 'Disable given profile(s), does not toggle')
             [CompletionResult]::new('-i', '-i', [CompletionResultType]::ParameterName, 'Reverse the processing order (first listed = highest priority)')
             [CompletionResult]::new('--inverse', '--inverse', [CompletionResultType]::ParameterName, 'Reverse the processing order (first listed = highest priority)')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
@@ -178,6 +182,10 @@ Register-ArgumentCompleter -Native -CommandName 'am' -ScriptBlock {
         'am;use' {
             [CompletionResult]::new('-n', '-n', [CompletionResultType]::ParameterName, 'Activate at specific priority position (1-based). Repositions if already active')
             [CompletionResult]::new('--priority', '--priority', [CompletionResultType]::ParameterName, 'Activate at specific priority position (1-based). Repositions if already active')
+            [CompletionResult]::new('-e', '-e', [CompletionResultType]::ParameterName, 'Enable given profile(s), does not toggle')
+            [CompletionResult]::new('--enable', '--enable', [CompletionResultType]::ParameterName, 'Enable given profile(s), does not toggle')
+            [CompletionResult]::new('-d', '-d', [CompletionResultType]::ParameterName, 'Disable given profile(s), does not toggle')
+            [CompletionResult]::new('--disable', '--disable', [CompletionResultType]::ParameterName, 'Disable given profile(s), does not toggle')
             [CompletionResult]::new('-i', '-i', [CompletionResultType]::ParameterName, 'Reverse the processing order (first listed = highest priority)')
             [CompletionResult]::new('--inverse', '--inverse', [CompletionResultType]::ParameterName, 'Reverse the processing order (first listed = highest priority)')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')

--- a/completions/zsh/_am
+++ b/completions/zsh/_am
@@ -109,6 +109,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '(-i --inverse)-n+[Activate at specific priority position (1-based). Repositions if already active]:PRIORITY:_default' \
 '(-i --inverse)--priority=[Activate at specific priority position (1-based). Repositions if already active]:PRIORITY:_default' \
+'(-d --disable)-e[Enable given profile(s), does not toggle]' \
+'(-d --disable)--enable[Enable given profile(s), does not toggle]' \
+'(-e --enable)-d[Disable given profile(s), does not toggle]' \
+'(-e --enable)--disable[Disable given profile(s), does not toggle]' \
 '(-n --priority)-i[Reverse the processing order (first listed = highest priority)]' \
 '(-n --priority)--inverse[Reverse the processing order (first listed = highest priority)]' \
 '-h[Print help]' \
@@ -203,6 +207,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '(-i --inverse)-n+[Activate at specific priority position (1-based). Repositions if already active]:PRIORITY:_default' \
 '(-i --inverse)--priority=[Activate at specific priority position (1-based). Repositions if already active]:PRIORITY:_default' \
+'(-d --disable)-e[Enable given profile(s), does not toggle]' \
+'(-d --disable)--enable[Enable given profile(s), does not toggle]' \
+'(-e --enable)-d[Disable given profile(s), does not toggle]' \
+'(-e --enable)--disable[Disable given profile(s), does not toggle]' \
 '(-n --priority)-i[Reverse the processing order (first listed = highest priority)]' \
 '(-n --priority)--inverse[Reverse the processing order (first listed = highest priority)]' \
 '-h[Print help]' \

--- a/crates/am/src/bin/am.rs
+++ b/crates/am/src/bin/am.rs
@@ -160,10 +160,22 @@ fn main() -> anyhow::Result<()> {
             println!("{}", amoxide::status::run_status());
             return Ok(());
         }
-        Commands::Use {
-            names,
+        Commands::Use(ProfileUse {
+            enable,
+            disable,
             priority,
             inverse,
+            names,
+        })
+        | Commands::Profile {
+            action:
+                Some(ProfileAction::Use(ProfileUse {
+                    enable,
+                    disable,
+                    priority,
+                    inverse,
+                    names,
+                })),
         } => {
             let ordered: Vec<String> = if *inverse {
                 names.iter().rev().cloned().collect()
@@ -172,7 +184,15 @@ fn main() -> anyhow::Result<()> {
             };
             let msg = match priority {
                 Some(n) => Message::UseProfilesAt(ordered, *n),
-                None => Message::ToggleProfiles(ordered),
+                None => {
+                    if *enable {
+                        Message::EnableProfiles(ordered)
+                    } else if *disable {
+                        Message::DeactivateProfiles(ordered)
+                    } else {
+                        Message::ToggleProfiles(ordered)
+                    }
+                }
             };
             let result = update(&mut model, msg)?;
             execute_effects(&mut model, result.effects)?;
@@ -185,25 +205,6 @@ fn main() -> anyhow::Result<()> {
         {
             ProfileAction::Add { name } => {
                 let result = update(&mut model, Message::CreateProfile(name.clone()))?;
-                execute_effects(&mut model, result.effects)?;
-                model.save_config()?;
-                return Ok(());
-            }
-            ProfileAction::Use {
-                names,
-                priority,
-                inverse,
-            } => {
-                let ordered: Vec<String> = if *inverse {
-                    names.iter().rev().cloned().collect()
-                } else {
-                    names.clone()
-                };
-                let msg = match priority {
-                    Some(n) => Message::UseProfilesAt(ordered, *n),
-                    None => Message::ToggleProfiles(ordered),
-                };
-                let result = update(&mut model, msg)?;
                 execute_effects(&mut model, result.effects)?;
                 model.save_config()?;
                 return Ok(());
@@ -246,6 +247,7 @@ fn main() -> anyhow::Result<()> {
                 return Ok(());
             }
             ProfileAction::List { used } => Message::ListProfiles { used: *used },
+            ProfileAction::Use(_) => unreachable!("handled by outer match arm"),
         },
         Commands::Setup { shell } => {
             amoxide::setup::run_setup(shell)?;

--- a/crates/am/src/cli.rs
+++ b/crates/am/src/cli.rs
@@ -91,16 +91,7 @@ pub enum Commands {
 
     /// Shortcut for `am profile use` — toggle one or more profiles
     #[command(alias = "u")]
-    Use {
-        /// Profile names
-        names: Vec<String>,
-        /// Activate at specific priority position (1-based). Repositions if already active.
-        #[arg(short = 'n', long = "priority", conflicts_with = "inverse")]
-        priority: Option<usize>,
-        /// Reverse the processing order (first listed = highest priority)
-        #[arg(short, long, conflicts_with = "priority")]
-        inverse: bool,
-    },
+    Use(ProfileUse),
 
     /// Launch the interactive TUI for managing aliases and profiles
     #[command(alias = "t")]
@@ -139,6 +130,24 @@ pub enum Commands {
     },
 }
 
+#[derive(Args)]
+pub struct ProfileUse {
+    /// Enable given profile(s), does not toggle
+    #[arg(short = 'e', long = "enable", conflicts_with = "disable")]
+    pub enable: bool,
+    /// Disable given profile(s), does not toggle
+    #[arg(short = 'd', long = "disable", conflicts_with = "enable")]
+    pub disable: bool,
+    /// Activate at specific priority position (1-based). Repositions if already active.
+    #[arg(short = 'n', long = "priority", conflicts_with = "inverse")]
+    pub priority: Option<usize>,
+    /// Reverse the processing order (first listed = highest priority)
+    #[arg(short, long, conflicts_with = "priority")]
+    pub inverse: bool,
+    /// Profile names
+    pub names: Vec<String>,
+}
+
 #[derive(Subcommand)]
 pub enum ProfileAction {
     /// Add a new profile
@@ -150,16 +159,7 @@ pub enum ProfileAction {
 
     /// Toggle one or more profiles as active/inactive, optionally at a specific priority
     #[command(alias = "u")]
-    Use {
-        /// Profile names
-        names: Vec<String>,
-        /// Activate at specific priority position (1-based). Repositions if already active.
-        #[arg(short = 'n', long = "priority", conflicts_with = "inverse")]
-        priority: Option<usize>,
-        /// Reverse the processing order (first listed = highest priority)
-        #[arg(short, long, conflicts_with = "priority")]
-        inverse: bool,
-    },
+    Use(ProfileUse),
 
     /// Remove a profile
     #[command(alias = "r")]

--- a/crates/am/src/messages.rs
+++ b/crates/am/src/messages.rs
@@ -38,6 +38,8 @@ pub enum Message {
     Sync(Shell, bool),
 
     ToggleProfiles(Vec<String>),
+    EnableProfiles(Vec<String>),
+    DeactivateProfiles(Vec<String>),
     UseProfilesAt(Vec<String>, usize),
     RemoveProfile(String),
     ListProfiles {

--- a/crates/am/src/update.rs
+++ b/crates/am/src/update.rs
@@ -755,8 +755,11 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
                 Ok(UpdateResult::effect(Effect::RenderSync(outcome)))
             }
         }
-        Message::ToggleProfiles(names) => {
-            for name in &names {
+        Message::ToggleProfiles(ref names)
+        | Message::EnableProfiles(ref names)
+        | Message::DeactivateProfiles(ref names) => {
+            // ensues they all exist, so all or nothing
+            for name in names {
                 model
                     .profile_config()
                     .get_profile_by_name(name)
@@ -765,15 +768,33 @@ pub fn update(model: &mut AppModel, message: Message) -> Result<UpdateResult, Up
             let project_names = project_alias_names(model);
             let mut effects = Vec::new();
             for name in names {
-                let was_active = model.session.is_active(&name);
+                let is_active = model.session.is_active(name);
                 let items = model
                     .profile_config()
-                    .get_profile_by_name(&name)
+                    .get_profile_by_name(name)
                     .map(profile_items)
                     .unwrap_or_default();
-                model.session.toggle_profile(name.clone());
-                let msg = profile_toggle_message(&name, !was_active, None, &items, &project_names);
-                effects.push(Effect::Print(msg));
+                if matches!(message, Message::EnableProfiles(_)) && is_active {
+                    effects.push(Effect::Print(format!(
+                        "am: profile '{name}' is already active"
+                    )));
+                    continue;
+                } else if matches!(message, Message::DeactivateProfiles(_)) && !is_active {
+                    effects.push(Effect::Print(format!(
+                        "am: profile '{name}' was already deactivated"
+                    )));
+                    continue;
+                } else {
+                    // in all other cases, toggle is what we want
+                    model.session.toggle_profile(name.clone());
+                    effects.push(Effect::Print(profile_toggle_message(
+                        name,
+                        !is_active,
+                        None,
+                        &items,
+                        &project_names,
+                    )));
+                }
             }
             effects.push(Effect::SaveSession);
             Ok(UpdateResult::with_effects(effects))
@@ -1454,6 +1475,77 @@ mod tests {
         assert!(matches!(result, Err(UpdateError::ProfileNotFound { name }) if name == "nope"));
         // git should NOT have been toggled since validation failed
         assert!(model.session.active_profiles.is_empty());
+    }
+
+    #[test]
+    fn enable_profile_activates_inactive_profile() {
+        let config = Config::default();
+        let profile_config: ProfileConfig =
+            toml::from_str("[[profiles]]\nname = \"git\"\n").unwrap();
+        let mut model = AppModel::new(config, profile_config);
+
+        let result = update(&mut model, Message::EnableProfiles(vec!["git".into()])).unwrap();
+
+        assert!(model.session.active_profiles.contains(&"git".to_string()));
+        assert!(
+            matches!(&result.effects[0], Effect::Print(s) if s.contains("git") && s.contains("activated"))
+        );
+    }
+
+    #[test]
+    fn enable_profile_noop_when_already_active() {
+        let config = Config::default();
+        let profile_config: ProfileConfig =
+            toml::from_str("[[profiles]]\nname = \"git\"\n").unwrap();
+        let mut model = AppModel::new(config, profile_config);
+        model.session.active_profiles = vec!["git".to_string()];
+
+        let result = update(&mut model, Message::EnableProfiles(vec!["git".into()])).unwrap();
+
+        assert_eq!(model.session.active_profiles, vec!["git".to_string()]);
+        assert!(matches!(&result.effects[0], Effect::Print(s) if s.contains("already active")));
+    }
+
+    #[test]
+    fn deactivate_profile_removes_active_profile() {
+        let config = Config::default();
+        let profile_config: ProfileConfig =
+            toml::from_str("[[profiles]]\nname = \"git\"\n").unwrap();
+        let mut model = AppModel::new(config, profile_config);
+        model.session.active_profiles = vec!["git".to_string()];
+
+        let result = update(&mut model, Message::DeactivateProfiles(vec!["git".into()])).unwrap();
+
+        assert!(model.session.active_profiles.is_empty());
+        assert!(
+            matches!(&result.effects[0], Effect::Print(s) if s.contains("git") && s.contains("deactivated"))
+        );
+    }
+
+    #[test]
+    fn deactivate_profile_noop_when_already_inactive() {
+        let config = Config::default();
+        let profile_config: ProfileConfig =
+            toml::from_str("[[profiles]]\nname = \"git\"\n").unwrap();
+        let mut model = AppModel::new(config, profile_config);
+
+        let result = update(&mut model, Message::DeactivateProfiles(vec!["git".into()])).unwrap();
+
+        assert!(model.session.active_profiles.is_empty());
+        assert!(
+            matches!(&result.effects[0], Effect::Print(s) if s.contains("already deactivated"))
+        );
+    }
+
+    #[test]
+    fn enable_profile_fails_if_missing() {
+        let config = Config::default();
+        let profile_config = ProfileConfig::default();
+        let mut model = AppModel::new(config, profile_config);
+
+        let result = update(&mut model, Message::EnableProfiles(vec!["nope".into()]));
+
+        assert!(matches!(result, Err(UpdateError::ProfileNotFound { name }) if name == "nope"));
     }
 
     #[test]

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_bash_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_bash_simple_profile.snap
@@ -753,7 +753,7 @@ _am() {
             return 0
             ;;
         am__subcmd__profile__subcmd__use)
-            opts="-n -i -h -V --priority --inverse --help --version [NAMES]..."
+            opts="-e -d -n -i -h -V --enable --disable --priority --inverse --help --version [NAMES]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -907,7 +907,7 @@ _am() {
             return 0
             ;;
         am__subcmd__use)
-            opts="-n -i -h -V --priority --inverse --help --version [NAMES]..."
+            opts="-e -d -n -i -h -V --enable --disable --priority --inverse --help --version [NAMES]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_bash_with_kubectl_subcommands.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_bash_with_kubectl_subcommands.snap
@@ -782,7 +782,7 @@ _am() {
             return 0
             ;;
         am__subcmd__profile__subcmd__use)
-            opts="-n -i -h -V --priority --inverse --help --version [NAMES]..."
+            opts="-e -d -n -i -h -V --enable --disable --priority --inverse --help --version [NAMES]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -936,7 +936,7 @@ _am() {
             return 0
             ;;
         am__subcmd__use)
-            opts="-n -i -h -V --priority --inverse --help --version [NAMES]..."
+            opts="-e -d -n -i -h -V --enable --disable --priority --inverse --help --version [NAMES]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_deep_chain.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_deep_chain.snap
@@ -121,6 +121,8 @@ complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subco
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s e -l enable -d 'Enable given profile(s), does not toggle'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s d -l disable -d 'Disable given profile(s), does not toggle'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s V -l version -d 'Print version'
@@ -141,6 +143,8 @@ complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print ve
 complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand setup" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand use" -s e -l enable -d 'Enable given profile(s), does not toggle'
+complete -c am -n "__fish_am_using_subcommand use" -s d -l disable -d 'Disable given profile(s), does not toggle'
 complete -c am -n "__fish_am_using_subcommand use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
 complete -c am -n "__fish_am_using_subcommand use" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand use" -s V -l version -d 'Print version'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_globals_and_multi_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_globals_and_multi_profile.snap
@@ -127,6 +127,8 @@ complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subco
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s e -l enable -d 'Enable given profile(s), does not toggle'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s d -l disable -d 'Disable given profile(s), does not toggle'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s V -l version -d 'Print version'
@@ -147,6 +149,8 @@ complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print ve
 complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand setup" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand use" -s e -l enable -d 'Enable given profile(s), does not toggle'
+complete -c am -n "__fish_am_using_subcommand use" -s d -l disable -d 'Disable given profile(s), does not toggle'
 complete -c am -n "__fish_am_using_subcommand use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
 complete -c am -n "__fish_am_using_subcommand use" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand use" -s V -l version -d 'Print version'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_multi_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_multi_profile.snap
@@ -121,6 +121,8 @@ complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subco
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s e -l enable -d 'Enable given profile(s), does not toggle'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s d -l disable -d 'Disable given profile(s), does not toggle'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s V -l version -d 'Print version'
@@ -141,6 +143,8 @@ complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print ve
 complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand setup" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand use" -s e -l enable -d 'Enable given profile(s), does not toggle'
+complete -c am -n "__fish_am_using_subcommand use" -s d -l disable -d 'Disable given profile(s), does not toggle'
 complete -c am -n "__fish_am_using_subcommand use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
 complete -c am -n "__fish_am_using_subcommand use" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand use" -s V -l version -d 'Print version'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_simple_profile.snap
@@ -115,6 +115,8 @@ complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subco
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s e -l enable -d 'Enable given profile(s), does not toggle'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s d -l disable -d 'Disable given profile(s), does not toggle'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s V -l version -d 'Print version'
@@ -135,6 +137,8 @@ complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print ve
 complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand setup" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand use" -s e -l enable -d 'Enable given profile(s), does not toggle'
+complete -c am -n "__fish_am_using_subcommand use" -s d -l disable -d 'Disable given profile(s), does not toggle'
 complete -c am -n "__fish_am_using_subcommand use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
 complete -c am -n "__fish_am_using_subcommand use" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand use" -s V -l version -d 'Print version'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_globals.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_globals.snap
@@ -115,6 +115,8 @@ complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subco
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s e -l enable -d 'Enable given profile(s), does not toggle'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s d -l disable -d 'Disable given profile(s), does not toggle'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s V -l version -d 'Print version'
@@ -135,6 +137,8 @@ complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print ve
 complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand setup" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand use" -s e -l enable -d 'Enable given profile(s), does not toggle'
+complete -c am -n "__fish_am_using_subcommand use" -s d -l disable -d 'Disable given profile(s), does not toggle'
 complete -c am -n "__fish_am_using_subcommand use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
 complete -c am -n "__fish_am_using_subcommand use" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand use" -s V -l version -d 'Print version'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_simple_subcommands.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_simple_subcommands.snap
@@ -120,6 +120,8 @@ complete -c am -n "__fish_am_using_subcommand profile; and not __fish_seen_subco
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from add" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s e -l enable -d 'Enable given profile(s), does not toggle'
+complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s d -l disable -d 'Disable given profile(s), does not toggle'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand profile; and __fish_seen_subcommand_from use" -s V -l version -d 'Print version'
@@ -140,6 +142,8 @@ complete -c am -n "__fish_am_using_subcommand init" -s V -l version -d 'Print ve
 complete -c am -n "__fish_am_using_subcommand setup" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand setup" -s V -l version -d 'Print version'
 complete -c am -n "__fish_am_using_subcommand use" -s n -l priority -d 'Activate at specific priority position (1-based). Repositions if already active' -r
+complete -c am -n "__fish_am_using_subcommand use" -s e -l enable -d 'Enable given profile(s), does not toggle'
+complete -c am -n "__fish_am_using_subcommand use" -s d -l disable -d 'Disable given profile(s), does not toggle'
 complete -c am -n "__fish_am_using_subcommand use" -s i -l inverse -d 'Reverse the processing order (first listed = highest priority)'
 complete -c am -n "__fish_am_using_subcommand use" -s h -l help -d 'Print help'
 complete -c am -n "__fish_am_using_subcommand use" -s V -l version -d 'Print version'

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
@@ -159,6 +159,10 @@ Register-ArgumentCompleter -Native -CommandName 'am' -ScriptBlock {
         'am;profile;use' {
             [System.Management.Automation.CompletionResult]::new('-n', '-n', [System.Management.Automation.CompletionResultType]::ParameterName, 'Activate at specific priority position (1-based). Repositions if already active')
             [System.Management.Automation.CompletionResult]::new('--priority', '--priority', [System.Management.Automation.CompletionResultType]::ParameterName, 'Activate at specific priority position (1-based). Repositions if already active')
+            [System.Management.Automation.CompletionResult]::new('-e', '-e', [System.Management.Automation.CompletionResultType]::ParameterName, 'Enable given profile(s), does not toggle')
+            [System.Management.Automation.CompletionResult]::new('--enable', '--enable', [System.Management.Automation.CompletionResultType]::ParameterName, 'Enable given profile(s), does not toggle')
+            [System.Management.Automation.CompletionResult]::new('-d', '-d', [System.Management.Automation.CompletionResultType]::ParameterName, 'Disable given profile(s), does not toggle')
+            [System.Management.Automation.CompletionResult]::new('--disable', '--disable', [System.Management.Automation.CompletionResultType]::ParameterName, 'Disable given profile(s), does not toggle')
             [System.Management.Automation.CompletionResult]::new('-i', '-i', [System.Management.Automation.CompletionResultType]::ParameterName, 'Reverse the processing order (first listed = highest priority)')
             [System.Management.Automation.CompletionResult]::new('--inverse', '--inverse', [System.Management.Automation.CompletionResultType]::ParameterName, 'Reverse the processing order (first listed = highest priority)')
             [System.Management.Automation.CompletionResult]::new('-h', '-h', [System.Management.Automation.CompletionResultType]::ParameterName, 'Print help')
@@ -227,6 +231,10 @@ Register-ArgumentCompleter -Native -CommandName 'am' -ScriptBlock {
         'am;use' {
             [System.Management.Automation.CompletionResult]::new('-n', '-n', [System.Management.Automation.CompletionResultType]::ParameterName, 'Activate at specific priority position (1-based). Repositions if already active')
             [System.Management.Automation.CompletionResult]::new('--priority', '--priority', [System.Management.Automation.CompletionResultType]::ParameterName, 'Activate at specific priority position (1-based). Repositions if already active')
+            [System.Management.Automation.CompletionResult]::new('-e', '-e', [System.Management.Automation.CompletionResultType]::ParameterName, 'Enable given profile(s), does not toggle')
+            [System.Management.Automation.CompletionResult]::new('--enable', '--enable', [System.Management.Automation.CompletionResultType]::ParameterName, 'Enable given profile(s), does not toggle')
+            [System.Management.Automation.CompletionResult]::new('-d', '-d', [System.Management.Automation.CompletionResultType]::ParameterName, 'Disable given profile(s), does not toggle')
+            [System.Management.Automation.CompletionResult]::new('--disable', '--disable', [System.Management.Automation.CompletionResultType]::ParameterName, 'Disable given profile(s), does not toggle')
             [System.Management.Automation.CompletionResult]::new('-i', '-i', [System.Management.Automation.CompletionResultType]::ParameterName, 'Reverse the processing order (first listed = highest priority)')
             [System.Management.Automation.CompletionResult]::new('--inverse', '--inverse', [System.Management.Automation.CompletionResultType]::ParameterName, 'Reverse the processing order (first listed = highest priority)')
             [System.Management.Automation.CompletionResult]::new('-h', '-h', [System.Management.Automation.CompletionResultType]::ParameterName, 'Print help')

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_zsh_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_zsh_simple_profile.snap
@@ -138,6 +138,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '(-i --inverse)-n+[Activate at specific priority position (1-based). Repositions if already active]:PRIORITY:_default' \
 '(-i --inverse)--priority=[Activate at specific priority position (1-based). Repositions if already active]:PRIORITY:_default' \
+'(-d --disable)-e[Enable given profile(s), does not toggle]' \
+'(-d --disable)--enable[Enable given profile(s), does not toggle]' \
+'(-e --enable)-d[Disable given profile(s), does not toggle]' \
+'(-e --enable)--disable[Disable given profile(s), does not toggle]' \
 '(-n --priority)-i[Reverse the processing order (first listed = highest priority)]' \
 '(-n --priority)--inverse[Reverse the processing order (first listed = highest priority)]' \
 '-h[Print help]' \
@@ -232,6 +236,10 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '(-i --inverse)-n+[Activate at specific priority position (1-based). Repositions if already active]:PRIORITY:_default' \
 '(-i --inverse)--priority=[Activate at specific priority position (1-based). Repositions if already active]:PRIORITY:_default' \
+'(-d --disable)-e[Enable given profile(s), does not toggle]' \
+'(-d --disable)--enable[Enable given profile(s), does not toggle]' \
+'(-e --enable)-d[Disable given profile(s), does not toggle]' \
+'(-e --enable)--disable[Disable given profile(s), does not toggle]' \
 '(-n --priority)-i[Reverse the processing order (first listed = highest priority)]' \
 '(-n --priority)--inverse[Reverse the processing order (first listed = highest priority)]' \
 '-h[Print help]' \


### PR DESCRIPTION
## Summary

- Add `-e`/`--enable` and `-d`/`--disable` flags to `am use` and `am profile use`
- Enable is idempotent — no-op with message if already active
- Disable is idempotent — no-op with message if already inactive
- Without flags, toggle behavior is unchanged
- Shared `ProfileUse` struct deduplicates args between `am use` and `am profile use`

## Test plan

- [x] `am use -e git` on inactive profile — activates
- [x] `am use -e git` on active profile — prints "already active"
- [x] `am use -d git` on active profile — deactivates
- [x] `am use -d git` on inactive profile — prints "already deactivated"
- [x] `am use git` — still toggles as before

Closes #112