### PR TITLE
feat: debug mode poc — $__AM_DEBUG env-var gate, fish + powershell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ TODOs.md
 .worktrees/
 .superpowers/
 /tmp/
-.superpowers/
 
 # Website
 website/node_modules/
@@ -13,4 +12,8 @@ website/.vitepress/cache/
 website/.vitepress/dist/
 
 # Scratch buffer for release notes drafting (see `release-notes` project alias)
-RELEASE_NOTES_v*.md
+RELEASE_NOTES_*.md
+
+# MemPalace per-project files (issue #185)
+mempalace.yaml
+entities.json

--- a/crates/am/src/init.rs
+++ b/crates/am/src/init.rs
@@ -192,8 +192,8 @@ mod tests {
             &aliases,
             &SubcommandSet::new(),
         );
-        assert!(output.contains("function gs\n    git status $argv\nend"));
-        assert!(output.contains("function ll\n    ls -lha $argv\nend"));
+        assert!(output.contains("function gs\n    test \"$__AM_DEBUG\" = 1; and set -l fish_trace 1\n    git status $argv\nend"));
+        assert!(output.contains("function ll\n    test \"$__AM_DEBUG\" = 1; and set -l fish_trace 1\n    ls -lha $argv\nend"));
     }
 
     #[test]
@@ -298,7 +298,7 @@ mod tests {
             &AliasSet::default(),
             &SubcommandSet::new(),
         );
-        assert!(output.contains("function ll\n    ls -lha $argv\nend"));
+        assert!(output.contains("function ll\n    test \"$__AM_DEBUG\" = 1; and set -l fish_trace 1\n    ls -lha $argv\nend"));
     }
 
     #[test]

--- a/crates/am/src/precedence/diff.rs
+++ b/crates/am/src/precedence/diff.rs
@@ -266,7 +266,7 @@ mod tests {
             "changed b must be unloaded: {out}"
         );
         assert!(
-            out.contains("function b\n    make build $argv\nend"),
+            out.contains("function b\n    test \"$__AM_DEBUG\" = 1; and set -l fish_trace 1\n    make build $argv\nend"),
             "b must be reloaded: {out}"
         );
         // env-var update must be the last section

--- a/crates/am/src/shell/fish.rs
+++ b/crates/am/src/shell/fish.rs
@@ -12,6 +12,13 @@ use crate::alias::AliasEntry;
 use crate::config::FishConfig;
 use crate::subcommand::SubcommandEntry;
 
+/// Runtime debug-trace prelude injected into every emitted fish function body.
+/// When the user's shell has `__AM_DEBUG=1`, this enables fish's native
+/// `fish_trace` for the duration of the function — printing each expanded
+/// statement on stderr before exec. With the var unset or `0`, this is a
+/// single no-op `test` call per invocation.
+const FISH_DEBUG_TRACE: &str = "test \"$__AM_DEBUG\" = 1; and set -l fish_trace 1";
+
 /// Extract the wrappable command word from an alias body — the actual program
 /// name to register `complete --wraps` against.
 ///
@@ -181,15 +188,18 @@ impl ShellAdapter for Fish {
         if !entry.raw && has_template_args(entry.command) {
             let body = substitute_fish(entry.command);
             format!(
-                "{prelude}\nfunction {name}\n    {body}\nend{wraps}",
+                "{prelude}\nfunction {name}\n    {FISH_DEBUG_TRACE}\n    {body}\nend{wraps}",
                 name = entry.name,
                 wraps = wraps_line.as_deref().unwrap_or(""),
             )
         } else if self.use_abbr {
+            // Abbreviations are syntactic expansions performed by fish before
+            // the function would run — there's no body to inject a tracer into,
+            // so they stay opaque to debug mode. See issue #143 PoC scope.
             format!("abbr --add {} {}", entry.name, quote_cmd(entry.command))
         } else {
             format!(
-                "{prelude}\nfunction {name}\n    {cmd} $argv\nend{wraps}",
+                "{prelude}\nfunction {name}\n    {FISH_DEBUG_TRACE}\n    {cmd} $argv\nend{wraps}",
                 name = entry.name,
                 cmd = entry.command,
                 wraps = wraps_line.as_deref().unwrap_or(""),
@@ -217,6 +227,7 @@ impl ShellAdapter for Fish {
     ) -> String {
         let mut lines = Vec::new();
         lines.push(format!("function {program} --wraps={program}"));
+        lines.push(format!("  {FISH_DEBUG_TRACE}"));
         let roots = build_wrapper_trie(entries);
         emit_fish_switch(&mut lines, &roots, 1, base_cmd, "  ");
         lines.push("end".into());
@@ -301,11 +312,11 @@ mod tests {
         // Body starting with a quote → no clean command word, skip --wraps.
         assert_eq!(
             Fish::default().alias(&simple("h", "'echo hello'")),
-            "functions -e h\ncomplete -e -c h\nfunction h\n    'echo hello' $argv\nend"
+            "functions -e h\ncomplete -e -c h\nfunction h\n    test \"$__AM_DEBUG\" = 1; and set -l fish_trace 1\n    'echo hello' $argv\nend"
         );
         assert_eq!(
             Fish::default().alias(&simple("h", "echo hello")),
-            "functions -e h\ncomplete -e -c h\nfunction h\n    echo hello $argv\nend\ncomplete -c h --wraps \"echo\""
+            "functions -e h\ncomplete -e -c h\nfunction h\n    test \"$__AM_DEBUG\" = 1; and set -l fish_trace 1\n    echo hello $argv\nend\ncomplete -c h --wraps \"echo\""
         );
     }
 
@@ -334,11 +345,11 @@ mod tests {
     fn test_fish_parameterized() {
         assert_eq!(
             Fish::default().alias(&simple("cmf", "cm feat: {{@}}")),
-            "functions -e cmf\ncomplete -e -c cmf\nfunction cmf\n    cm feat: $argv\nend\ncomplete -c cmf --wraps \"cm\""
+            "functions -e cmf\ncomplete -e -c cmf\nfunction cmf\n    test \"$__AM_DEBUG\" = 1; and set -l fish_trace 1\n    cm feat: $argv\nend\ncomplete -c cmf --wraps \"cm\""
         );
         assert_eq!(
             Fish::default().alias(&simple("x", "echo {{1}} and {{2}}")),
-            "functions -e x\ncomplete -e -c x\nfunction x\n    echo $argv[1] and $argv[2]\nend\ncomplete -c x --wraps \"echo\""
+            "functions -e x\ncomplete -e -c x\nfunction x\n    test \"$__AM_DEBUG\" = 1; and set -l fish_trace 1\n    echo $argv[1] and $argv[2]\nend\ncomplete -c x --wraps \"echo\""
         );
     }
 
@@ -346,7 +357,7 @@ mod tests {
     fn test_fish_raw_skips_templates() {
         assert_eq!(
             Fish::default().alias(&raw("my-awk", "awk '{print {{1}}}'")),
-            "functions -e my-awk\ncomplete -e -c my-awk\nfunction my-awk\n    awk '{print {{1}}}' $argv\nend\ncomplete -c my-awk --wraps \"awk\""
+            "functions -e my-awk\ncomplete -e -c my-awk\nfunction my-awk\n    test \"$__AM_DEBUG\" = 1; and set -l fish_trace 1\n    awk '{print {{1}}}' $argv\nend\ncomplete -c my-awk --wraps \"awk\""
         );
     }
 
@@ -502,7 +513,7 @@ mod tests {
         let fish = Fish { use_abbr: true };
         assert_eq!(
             fish.alias(&simple("cmf", "cm feat: {{@}}")),
-            "functions -e cmf\ncomplete -e -c cmf\nfunction cmf\n    cm feat: $argv\nend\ncomplete -c cmf --wraps \"cm\""
+            "functions -e cmf\ncomplete -e -c cmf\nfunction cmf\n    test \"$__AM_DEBUG\" = 1; and set -l fish_trace 1\n    cm feat: $argv\nend\ncomplete -c cmf --wraps \"cm\""
         );
     }
 

--- a/crates/am/src/shell/powershell.rs
+++ b/crates/am/src/shell/powershell.rs
@@ -21,6 +21,26 @@ fn substitute_offset(cmd: &str, offset: usize) -> String {
 use crate::alias::AliasEntry;
 use crate::subcommand::SubcommandEntry;
 
+/// Render `line` as the interior of a PowerShell double-quoted string literal.
+/// Escapes the two metacharacters that would break the surrounding `"…"`:
+/// the backtick (PS's escape character) and the literal `"`. Leaves `$(...)`
+/// subexpressions and `$args[N]` references intact so PS interpolates them
+/// at call time — that's the whole point of the trace line.
+fn ps_trace_escape(line: &str) -> String {
+    line.replace('`', "``").replace('"', "`\"")
+}
+
+/// Emit a one-line debug gate. When `$env:__AM_DEBUG` is `1`, writes the
+/// post-expansion command to stderr (so it doesn't intermix with the real
+/// stdout the wrapped command produces). When unset/`0`, the `if` short-
+/// circuits — no side effect.
+fn ps_trace(line: &str) -> String {
+    format!(
+        "if ($env:__AM_DEBUG -eq '1') {{ [Console]::Error.WriteLine(\"[am] {}\") }}; ",
+        ps_trace_escape(line)
+    )
+}
+
 #[derive(Debug, Default)]
 pub struct PowerShell;
 
@@ -32,10 +52,16 @@ impl ShellAdapter for PowerShell {
     fn alias(&self, entry: &AliasEntry) -> String {
         if !entry.raw && has_template_args(entry.command) {
             let body = substitute_powershell(entry.command);
-            format!("function global:{} {{ {} }}", entry.name, body)
+            let trace = ps_trace(&body);
+            format!("function global:{} {{ {trace}{body} }}", entry.name)
         } else {
+            // Non-parameterised: real call uses `@args` (splat); trace shows
+            // `$args` (space-joined interpolation) — visually equivalent for
+            // simple cases and avoids the splat-vs-interpolate mismatch
+            // inside a "..." literal.
+            let trace = ps_trace(&format!("{} $args", entry.command));
             format!(
-                "function global:{} {{ {} @args }}",
+                "function global:{} {{ {trace}{} @args }}",
                 entry.name, entry.command
             )
         }
@@ -91,7 +117,10 @@ fn emit_ps_switch(
         emit_ps_node_body(lines, node, depth, ps_base, &format!("{indent}    "));
         lines.push(format!("{indent}  }}"));
     }
-    lines.push(format!("{indent}  default {{ {ps_base} @args }}"));
+    let outer_default_trace = ps_trace(&format!("{ps_base} $args"));
+    lines.push(format!(
+        "{indent}  default {{ {outer_default_trace}{ps_base} @args }}"
+    ));
     lines.push(format!("{indent}}}"));
 }
 
@@ -106,17 +135,20 @@ fn emit_ps_node_body(
 ) {
     let next_depth = depth + 1;
     if node.children.is_empty() {
-        // Leaf node: emit the expansion.
+        // Leaf node: emit the expansion (and its trace).
         let expansion = node.leaf_longs.as_deref().unwrap_or_default().join(" ");
         if has_template_args(&expansion) {
-            lines.push(format!(
-                "{indent}{ps_base} {}",
-                substitute_offset(&expansion, next_depth)
-            ));
+            let resolved = substitute_offset(&expansion, next_depth);
+            let trace = ps_trace(&format!("{ps_base} {resolved}"));
+            lines.push(format!("{indent}{trace}{ps_base} {resolved}"));
         } else {
-            lines.push(format!(
-                "{indent}{ps_base} {expansion} ($args | Select-Object -Skip {next_depth})"
-            ));
+            // Trace shows the tail via $(($args | Select-Object -Skip N)) so
+            // the printed line reflects the actual args the wrapped command
+            // will receive, not the literal pipeline expression.
+            let tail_real = format!("($args | Select-Object -Skip {next_depth})");
+            let tail_trace = format!("$(($args | Select-Object -Skip {next_depth}))");
+            let trace = ps_trace(&format!("{ps_base} {expansion} {tail_trace}"));
+            lines.push(format!("{indent}{trace}{ps_base} {expansion} {tail_real}"));
         }
     } else {
         // Intermediate node with children: emit a nested switch.
@@ -130,17 +162,22 @@ fn emit_ps_node_body(
         if let Some(longs) = &node.leaf_longs {
             let expansion = longs.join(" ");
             if has_template_args(&expansion) {
+                let resolved = substitute_offset(&expansion, next_depth);
+                let trace = ps_trace(&format!("{ps_base} {resolved}"));
                 lines.push(format!(
-                    "{indent}  default {{ {ps_base} {} }}",
-                    substitute_offset(&expansion, next_depth)
+                    "{indent}  default {{ {trace}{ps_base} {resolved} }}"
                 ));
             } else {
+                let tail_real = format!("($args | Select-Object -Skip {next_depth})");
+                let tail_trace = format!("$(($args | Select-Object -Skip {next_depth}))");
+                let trace = ps_trace(&format!("{ps_base} {expansion} {tail_trace}"));
                 lines.push(format!(
-                    "{indent}  default {{ {ps_base} {expansion} ($args | Select-Object -Skip {next_depth}) }}"
+                    "{indent}  default {{ {trace}{ps_base} {expansion} {tail_real} }}"
                 ));
             }
         } else {
-            lines.push(format!("{indent}  default {{ {ps_base} @args }}"));
+            let trace = ps_trace(&format!("{ps_base} $args"));
+            lines.push(format!("{indent}  default {{ {trace}{ps_base} @args }}"));
         }
         lines.push(format!("{indent}}}"));
     }
@@ -152,11 +189,23 @@ mod tests {
     use crate::shell::test_helpers::{raw, simple};
     use crate::subcommand::SubcommandEntry;
 
+    /// Inline copy of the debug-gate format used inside emitted PS function
+    /// bodies. Tests build the expected output by formatting against the
+    /// post-expansion form — same shape `ps_trace` produces in src.
+    fn gate(traced: &str) -> String {
+        format!(
+            "if ($env:__AM_DEBUG -eq '1') {{ [Console]::Error.WriteLine(\"[am] {traced}\") }}; "
+        )
+    }
+
     #[test]
     fn test_simple_alias() {
         assert_eq!(
             PowerShell.alias(&simple("gs", "git status")),
-            "function global:gs { git status @args }"
+            format!(
+                "function global:gs {{ {}git status @args }}",
+                gate("git status $args")
+            )
         );
     }
 
@@ -164,11 +213,17 @@ mod tests {
     fn test_parameterized_alias() {
         assert_eq!(
             PowerShell.alias(&simple("cmf", "cm feat: {{@}}")),
-            "function global:cmf { cm feat: $args }"
+            format!(
+                "function global:cmf {{ {}cm feat: $args }}",
+                gate("cm feat: $args")
+            )
         );
         assert_eq!(
             PowerShell.alias(&simple("x", "echo {{1}} and {{2}}")),
-            "function global:x { echo $($args[0]) and $($args[1]) }"
+            format!(
+                "function global:x {{ {}echo $($args[0]) and $($args[1]) }}",
+                gate("echo $($args[0]) and $($args[1])")
+            )
         );
     }
 
@@ -176,7 +231,28 @@ mod tests {
     fn test_raw_alias() {
         assert_eq!(
             PowerShell.alias(&raw("my-awk", "awk '{print {{1}}}'")),
-            "function global:my-awk { awk '{print {{1}}}' @args }"
+            format!(
+                "function global:my-awk {{ {}awk '{{print {{{{1}}}}}}' @args }}",
+                gate("awk '{print {{1}}}' $args")
+            )
+        );
+    }
+
+    #[test]
+    fn test_ps_trace_escapes_inner_quotes() {
+        // Body with an embedded "..." (the headline case from issue #143):
+        // git cm → commit -m "{{1}}" --signoff
+        let out = PowerShell.alias(&simple("cm", "git commit -m \"{{1}}\" --signoff"));
+        // Inside the trace literal, the inner " must be backtick-escaped so
+        // PS doesn't terminate the WriteLine argument.
+        assert!(
+            out.contains("[am] git commit -m `\"$($args[0])`\" --signoff"),
+            "trace should backtick-escape inner quotes: {out}"
+        );
+        // The real call still uses unescaped double-quotes.
+        assert!(
+            out.contains("git commit -m \"$($args[0])\" --signoff }"),
+            "real call must keep literal quotes: {out}"
         );
     }
 

--- a/crates/am/src/shell_wrappers/hook.ps1
+++ b/crates/am/src/shell_wrappers/hook.ps1
@@ -5,6 +5,7 @@ function global:prompt {
     if ($PWD.Path -ne $env:__AM_LAST_DIR) {
         $env:__AM_LAST_DIR = $PWD.Path
         $amBin = (Get-Command -CommandType Application am | Select-Object -First 1).Source
+        if ($env:__AM_DEBUG -eq '1') { [Console]::Error.WriteLine("[am] hook: syncing $($PWD.Path)") }
         $hookCode = (& $amBin sync __SHELL__) -join "`r`n"
         if ($hookCode) { Invoke-Command -ScriptBlock ([scriptblock]::Create($hookCode)) -NoNewScope }
     }

--- a/crates/am/src/shell_wrappers/wrapper.ps1
+++ b/crates/am/src/shell_wrappers/wrapper.ps1
@@ -8,10 +8,12 @@ function am {
     $second = if ($args.Count -ge 2) { $args[1] } else { $null }
 
     $runSync = {
+        if ($env:__AM_DEBUG -eq '1') { [Console]::Error.WriteLine("[am] wrapper: sync after '$first'") }
         $out = (& $amBin sync __SHELL__) -join "`r`n"
         if ($out) { Invoke-Command -ScriptBlock ([scriptblock]::Create($out)) -NoNewScope }
     }
     $runSyncQuiet = {
+        if ($env:__AM_DEBUG -eq '1') { [Console]::Error.WriteLine("[am] wrapper: sync (quiet) after '$first'") }
         $out = (& $amBin sync --quiet __SHELL__) -join "`r`n"
         if ($out) { Invoke-Command -ScriptBlock ([scriptblock]::Create($out)) -NoNewScope }
     }

--- a/crates/am/tests/snapshots.rs
+++ b/crates/am/tests/snapshots.rs
@@ -756,7 +756,7 @@ fn sync_fresh_load_emits_aliases_and_env_var() {
         .diff;
     let shell = Shell::Fish.as_shell(&Default::default(), Default::default(), Default::default());
     let out = diff.render(shell.as_ref());
-    assert!(out.contains("function gs\n    git status $argv\nend"));
+    assert!(out.contains("function gs\n    test \"$__AM_DEBUG\" = 1; and set -l fish_trace 1\n    git status $argv\nend"));
     assert!(out.contains("_AM_ALIASES"));
     assert!(out.contains("gs|"));
 }

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_deep_chain.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_deep_chain.snap
@@ -5,18 +5,21 @@ expression: output
 functions -e ct
 complete -e -c ct
 function ct
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     cargo test $argv
 end
 complete -c ct --wraps "cargo"
 functions -e gs
 complete -e -c gs
 function gs
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     git status $argv
 end
 complete -c gs --wraps "git"
 functions -e ll
 complete -e -c ll
 function ll
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     ls -lha $argv
 end
 complete -c ll --wraps "ls"

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_globals_and_multi_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_globals_and_multi_profile.snap
@@ -5,24 +5,28 @@ expression: output
 functions -e cm
 complete -e -c cm
 function cm
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     git commit -sm $argv
 end
 complete -c cm --wraps "git"
 functions -e cmf
 complete -e -c cmf
 function cmf
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     cm feat: $argv
 end
 complete -c cmf --wraps "cm"
 functions -e gs
 complete -e -c gs
 function gs
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     git status $argv
 end
 complete -c gs --wraps "git"
 functions -e ll
 complete -e -c ll
 function ll
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     ls -lha $argv
 end
 complete -c ll --wraps "ls"

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_multi_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_multi_profile.snap
@@ -5,18 +5,21 @@ expression: output
 functions -e cm
 complete -e -c cm
 function cm
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     git commit -sm $argv
 end
 complete -c cm --wraps "git"
 functions -e cmf
 complete -e -c cmf
 function cmf
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     cm feat: $argv
 end
 complete -c cmf --wraps "cm"
 functions -e gs
 complete -e -c gs
 function gs
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     git status $argv
 end
 complete -c gs --wraps "git"

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_simple_profile.snap
@@ -5,12 +5,14 @@ expression: output
 functions -e gs
 complete -e -c gs
 function gs
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     git status $argv
 end
 complete -c gs --wraps "git"
 functions -e ll
 complete -e -c ll
 function ll
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     ls -lha $argv
 end
 complete -c ll --wraps "ls"

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_globals.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_globals.snap
@@ -5,12 +5,14 @@ expression: output
 functions -e ct
 complete -e -c ct
 function ct
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     cargo test $argv
 end
 complete -c ct --wraps "cargo"
 functions -e ll
 complete -e -c ll
 function ll
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     ls -lha $argv
 end
 complete -c ll --wraps "ls"

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_simple_subcommands.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_simple_subcommands.snap
@@ -5,10 +5,12 @@ expression: output
 functions -e gs
 complete -e -c gs
 function gs
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     git status $argv
 end
 complete -c gs --wraps "git"
 function jj --wraps=jj
+  test "$__AM_DEBUG" = 1; and set -l fish_trace 1
   switch $argv[1]
     case 'ab'
       command jj abandon $argv[2..]

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
@@ -2,8 +2,8 @@
 source: crates/am/tests/snapshots.rs
 expression: output
 ---
-function global:gs { git status @args }
-function global:ll { ls -lha @args }
+function global:gs { if ($env:__AM_DEBUG -eq '1') { [Console]::Error.WriteLine("[am] git status $args") }; git status @args }
+function global:ll { if ($env:__AM_DEBUG -eq '1') { [Console]::Error.WriteLine("[am] ls -lha $args") }; ls -lha @args }
 $env:_AM_ALIASES = "gs|22db469,ll|619d266"
 # am wrapper: sync after mutations
 function am {
@@ -15,10 +15,12 @@ function am {
     $second = if ($args.Count -ge 2) { $args[1] } else { $null }
 
     $runSync = {
+        if ($env:__AM_DEBUG -eq '1') { [Console]::Error.WriteLine("[am] wrapper: sync after '$first'") }
         $out = (& $amBin sync powershell) -join "`r`n"
         if ($out) { Invoke-Command -ScriptBlock ([scriptblock]::Create($out)) -NoNewScope }
     }
     $runSyncQuiet = {
+        if ($env:__AM_DEBUG -eq '1') { [Console]::Error.WriteLine("[am] wrapper: sync (quiet) after '$first'") }
         $out = (& $amBin sync --quiet powershell) -join "`r`n"
         if ($out) { Invoke-Command -ScriptBlock ([scriptblock]::Create($out)) -NoNewScope }
     }
@@ -45,6 +47,7 @@ function global:prompt {
     if ($PWD.Path -ne $env:__AM_LAST_DIR) {
         $env:__AM_LAST_DIR = $PWD.Path
         $amBin = (Get-Command -CommandType Application am | Select-Object -First 1).Source
+        if ($env:__AM_DEBUG -eq '1') { [Console]::Error.WriteLine("[am] hook: syncing $($PWD.Path)") }
         $hookCode = (& $amBin sync powershell) -join "`r`n"
         if ($hookCode) { Invoke-Command -ScriptBlock ([scriptblock]::Create($hookCode)) -NoNewScope }
     }

--- a/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_fresh_load_project_only.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_fresh_load_project_only.snap
@@ -5,12 +5,14 @@ expression: output
 functions -e b
 complete -e -c b
 function b
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     cargo build $argv
 end
 complete -c b --wraps "cargo"
 functions -e t
 complete -e -c t
 function t
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     cargo test $argv
 end
 complete -c t --wraps "cargo"

--- a/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_incremental_one_alias_updated.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_incremental_one_alias_updated.snap
@@ -6,6 +6,7 @@ functions -e b
 functions -e b
 complete -e -c b
 function b
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     cargo build --release $argv
 end
 complete -c b --wraps "cargo"

--- a/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_leaving_project_with_shadow_restoration.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_leaving_project_with_shadow_restoration.snap
@@ -7,6 +7,7 @@ functions -e t
 functions -e t
 complete -e -c t
 function t
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     cargo test $argv
 end
 complete -c t --wraps "cargo"

--- a/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_transition_to_new_project.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_transition_to_new_project.snap
@@ -6,6 +6,7 @@ functions -e old1
 functions -e new1
 complete -e -c new1
 function new1
+    test "$__AM_DEBUG" = 1; and set -l fish_trace 1
     echo new $argv
 end
 complete -c new1 --wraps "echo"

--- a/crates/am/tests/snapshots/snapshots__snapshot_sync_powershell_fresh_load_project_only.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_sync_powershell_fresh_load_project_only.snap
@@ -2,5 +2,5 @@
 source: crates/am/tests/snapshots.rs
 expression: output
 ---
-function global:b { cargo build @args }
+function global:b { if ($env:__AM_DEBUG -eq '1') { [Console]::Error.WriteLine("[am] cargo build $args") }; cargo build @args }
 $env:_AM_ALIASES = "b|b58de66"


### PR DESCRIPTION
## Why

A user [asked for visibility](https://github.com/sassman/amoxide-rs/issues/143) into how an alias actually resolves at call time — particularly to understand nested alias chains. This PoC adds the smallest possible surface that answers that question, scoped to fish and PowerShell so the shape can be evaluated before deciding on a config/CLI design.

## What changed

- Set `__AM_DEBUG=1` in the shell to enable, unset (or `0`) to disable. No `am` subcommand, no config field.
- Each emitted alias function checks the env var at call time and, when on, prints the post-expansion call to stderr. Off-mode cost is one `test`/`if` per invocation.
- Fish: uses native `fish_trace`, so quoting, glob expansion, and the silent template arg-drop are all visible. Per-function scope — no global tracer pollution.
- PowerShell: prints `[am] <resolved>` via `[Console]::Error.WriteLine` (rejected `Set-PSDebug -Trace` because it shows source lines, not resolved ones, and is process-global). Covers alias bodies, subcommand wrappers, the `am` mutation wrapper, and the cd hook.
- Closes #143.