### PR TITLE
fix: aliases not loaded on powershell session start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ TODOs.md
 .worktrees/
 .superpowers/
 /tmp/
-.superpowers/
 
 # Website
 website/node_modules/
@@ -13,4 +12,8 @@ website/.vitepress/cache/
 website/.vitepress/dist/
 
 # Scratch buffer for release notes drafting (see `release-notes` project alias)
-RELEASE_NOTES_v*.md
+RELEASE_NOTES_*.md
+
+# MemPalace per-project files (issue #185)
+mempalace.yaml
+entities.json

--- a/crates/am/src/precedence/diff.rs
+++ b/crates/am/src/precedence/diff.rs
@@ -211,11 +211,19 @@ impl PrecedenceDiff {
             }
         }
 
+        let any_change =
+            !self.removed.is_empty() || !self.added.is_empty() || !self.changed.is_empty();
         if !alias_list.is_empty() {
             lines.push(shell.set_env(env_vars::AM_ALIASES, &alias_list.to_string()));
+        } else if any_change {
+            // All aliases were removed — clear the tracking var so the next sync
+            // doesn't see stale names and mistakenly compute an empty diff.
+            lines.push(shell.unset_env(env_vars::AM_ALIASES));
         }
         if !sub_list.is_empty() {
             lines.push(shell.set_env(env_vars::AM_SUBCOMMANDS, &sub_list.to_string()));
+        } else if any_change {
+            lines.push(shell.unset_env(env_vars::AM_SUBCOMMANDS));
         }
 
         lines.join("\n")

--- a/crates/am/src/shell_wrappers/hook.ps1
+++ b/crates/am/src/shell_wrappers/hook.ps1
@@ -1,5 +1,4 @@
 # am cd hook: sync project aliases on directory change
-$env:__AM_LAST_DIR = $PWD.Path
 $__am_original_prompt = $function:prompt
 function global:prompt {
     if ($PWD.Path -ne $env:__AM_LAST_DIR) {
@@ -10,3 +9,13 @@ function global:prompt {
     }
     if ($__am_original_prompt) { & $__am_original_prompt } else { "PS $($PWD.Path)> " }
 }
+# Immediately sync the current directory, matching bash/zsh/fish hook behavior.
+& {
+    $amBin = (Get-Command -CommandType Application am | Select-Object -First 1).Source
+    if ($amBin) {
+        if ($env:__AM_DEBUG -eq '1') { [Console]::Error.WriteLine("[am] hook: initial sync $($PWD.Path)") }
+        $initCode = (& $amBin sync __SHELL__) -join "`r`n"
+        if ($initCode) { Invoke-Command -ScriptBlock ([scriptblock]::Create($initCode)) -NoNewScope }
+    }
+}
+$env:__AM_LAST_DIR = $PWD.Path

--- a/crates/am/src/shell_wrappers/hook.ps1
+++ b/crates/am/src/shell_wrappers/hook.ps1
@@ -9,6 +9,12 @@ function global:prompt {
     }
     if ($__am_original_prompt) { & $__am_original_prompt } else { "PS $($PWD.Path)> " }
 }
+# Clear inherited alias tracking so the immediate sync always re-loads correctly.
+# Stale _AM_ALIASES from a parent process or a previous `am sync` in this session
+# would otherwise make `am sync` think all aliases are already defined, causing it
+# to output nothing and leaving the shell with no aliases.
+Remove-Item -ErrorAction SilentlyContinue Env:_AM_ALIASES
+Remove-Item -ErrorAction SilentlyContinue Env:_AM_PROJECT_PATH
 # Immediately sync the current directory, matching bash/zsh/fish hook behavior.
 & {
     $amBin = (Get-Command -CommandType Application am | Select-Object -First 1).Source

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_bash_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_bash_simple_profile.snap
@@ -1,10 +1,12 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 182
 expression: output
 ---
 alias gs="git status"
 alias ll="ls -lha"
 export _AM_ALIASES="gs|22db469,ll|619d266"
+unset _AM_SUBCOMMANDS
 am() {
   command am "$@"
   local am_status=$?

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_deep_chain.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_deep_chain.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 227
 expression: output
 ---
 functions -e ct
@@ -21,6 +22,7 @@ function ll
 end
 complete -c ll --wraps "ls"
 set -gx _AM_ALIASES "ct|ab61de4,gs|22db469,ll|619d266"
+set -e _AM_SUBCOMMANDS
 # am wrapper: sync after mutations
 function am --wraps=am
     command am $argv

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_globals_and_multi_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_globals_and_multi_profile.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 295
 expression: output
 ---
 functions -e cm
@@ -27,6 +28,7 @@ function ll
 end
 complete -c ll --wraps "ls"
 set -gx _AM_ALIASES "cm|bed528f,cmf|9c99949,gs|22db469,ll|619d266"
+set -e _AM_SUBCOMMANDS
 # am wrapper: sync after mutations
 function am --wraps=am
     command am $argv

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_multi_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_multi_profile.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 195
 expression: output
 ---
 functions -e cm
@@ -21,6 +22,7 @@ function gs
 end
 complete -c gs --wraps "git"
 set -gx _AM_ALIASES "cm|bed528f,cmf|9c99949,gs|22db469"
+set -e _AM_SUBCOMMANDS
 # am wrapper: sync after mutations
 function am --wraps=am
     command am $argv

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_simple_profile.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 125
 expression: output
 ---
 functions -e gs
@@ -15,6 +16,7 @@ function ll
 end
 complete -c ll --wraps "ls"
 set -gx _AM_ALIASES "gs|22db469,ll|619d266"
+set -e _AM_SUBCOMMANDS
 # am wrapper: sync after mutations
 function am --wraps=am
     command am $argv

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_globals.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_fish_with_globals.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 214
 expression: output
 ---
 functions -e ct
@@ -15,6 +16,7 @@ function ll
 end
 complete -c ll --wraps "ls"
 set -gx _AM_ALIASES "ct|ab61de4,ll|619d266"
+set -e _AM_SUBCOMMANDS
 # am wrapper: sync after mutations
 function am --wraps=am
     command am $argv

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
@@ -39,7 +39,6 @@ function am {
 }
 
 # am cd hook: sync project aliases on directory change
-$env:__AM_LAST_DIR = $PWD.Path
 $__am_original_prompt = $function:prompt
 function global:prompt {
     if ($PWD.Path -ne $env:__AM_LAST_DIR) {
@@ -50,6 +49,16 @@ function global:prompt {
     }
     if ($__am_original_prompt) { & $__am_original_prompt } else { "PS $($PWD.Path)> " }
 }
+# Immediately sync the current directory, matching bash/zsh/fish hook behavior.
+& {
+    $amBin = (Get-Command -CommandType Application am | Select-Object -First 1).Source
+    if ($amBin) {
+        if ($env:__AM_DEBUG -eq '1') { [Console]::Error.WriteLine("[am] hook: initial sync $($PWD.Path)") }
+        $initCode = (& $amBin sync powershell) -join "`r`n"
+        if ($initCode) { Invoke-Command -ScriptBlock ([scriptblock]::Create($initCode)) -NoNewScope }
+    }
+}
+$env:__AM_LAST_DIR = $PWD.Path
 
 
 

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
@@ -6,6 +6,7 @@ expression: output
 function global:gs { git status @args }
 function global:ll { ls -lha @args }
 $env:_AM_ALIASES = "gs|22db469,ll|619d266"
+Remove-Item -ErrorAction SilentlyContinue Env:_AM_SUBCOMMANDS
 # am wrapper: sync after mutations
 function am {
     $amBin = (Get-Command -CommandType Application am | Select-Object -First 1).Source

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_powershell_simple_profile.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 163
 expression: output
 ---
 function global:gs { git status @args }
@@ -49,6 +50,12 @@ function global:prompt {
     }
     if ($__am_original_prompt) { & $__am_original_prompt } else { "PS $($PWD.Path)> " }
 }
+# Clear inherited alias tracking so the immediate sync always re-loads correctly.
+# Stale _AM_ALIASES from a parent process or a previous `am sync` in this session
+# would otherwise make `am sync` think all aliases are already defined, causing it
+# to output nothing and leaving the shell with no aliases.
+Remove-Item -ErrorAction SilentlyContinue Env:_AM_ALIASES
+Remove-Item -ErrorAction SilentlyContinue Env:_AM_PROJECT_PATH
 # Immediately sync the current directory, matching bash/zsh/fish hook behavior.
 & {
     $amBin = (Get-Command -CommandType Application am | Select-Object -First 1).Source

--- a/crates/am/tests/snapshots/snapshots__snapshot_init_zsh_simple_profile.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_init_zsh_simple_profile.snap
@@ -1,10 +1,12 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 144
 expression: output
 ---
 alias gs="git status"
 alias ll="ls -lha"
 export _AM_ALIASES="gs|22db469,ll|619d266"
+unset _AM_SUBCOMMANDS
 am() {
   command am "$@"
   local am_status=$?

--- a/crates/am/tests/snapshots/snapshots__snapshot_sync_bash_fresh_load_project_only.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_sync_bash_fresh_load_project_only.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 854
 expression: output
 ---
 alias b="cargo build"
 export _AM_ALIASES="b|b58de66"
+unset _AM_SUBCOMMANDS

--- a/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_fresh_load_project_only.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_fresh_load_project_only.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 837
 expression: output
 ---
 functions -e b
@@ -15,3 +16,4 @@ function t
 end
 complete -c t --wraps "cargo"
 set -gx _AM_ALIASES "b|b58de66,t|ab61de4"
+set -e _AM_SUBCOMMANDS

--- a/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_incremental_one_alias_updated.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_incremental_one_alias_updated.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 956
 expression: output
 ---
 functions -e b
@@ -10,3 +11,4 @@ function b
 end
 complete -c b --wraps "cargo"
 set -gx _AM_ALIASES "b|0dc3caa,t|ab61de4"
+set -e _AM_SUBCOMMANDS

--- a/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_leaving_project_with_shadow_restoration.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_leaving_project_with_shadow_restoration.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 935
 expression: output
 ---
 functions -e b
@@ -11,3 +12,4 @@ function t
 end
 complete -c t --wraps "cargo"
 set -gx _AM_ALIASES "t|ab61de4,ll|619d266"
+set -e _AM_SUBCOMMANDS

--- a/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_transition_to_new_project.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_sync_fish_transition_to_new_project.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 909
 expression: output
 ---
 functions -e old1
@@ -10,3 +11,4 @@ function new1
 end
 complete -c new1 --wraps "echo"
 set -gx _AM_ALIASES "new1|4d1fcee"
+set -e _AM_SUBCOMMANDS

--- a/crates/am/tests/snapshots/snapshots__snapshot_sync_powershell_fresh_load_project_only.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_sync_powershell_fresh_load_project_only.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 889
 expression: output
 ---
 function global:b { cargo build @args }
 $env:_AM_ALIASES = "b|b58de66"
+Remove-Item -ErrorAction SilentlyContinue Env:_AM_SUBCOMMANDS

--- a/crates/am/tests/snapshots/snapshots__snapshot_sync_zsh_fresh_load_project_only.snap
+++ b/crates/am/tests/snapshots/snapshots__snapshot_sync_zsh_fresh_load_project_only.snap
@@ -1,6 +1,8 @@
 ---
 source: crates/am/tests/snapshots.rs
+assertion_line: 871
 expression: output
 ---
 alias b="cargo build"
 export _AM_ALIASES="b|b58de66"
+unset _AM_SUBCOMMANDS


### PR DESCRIPTION
## Why

Starting a new PowerShell session left it with no project aliases until you `cd`'d elsewhere and back. The hook was wired only to the prompt's directory-change branch, so the initial directory was never synced. Cross-shell, the related env-var diff logic could also leave stale tracking names behind after a sync emptied the alias set — silently breaking the *next* sync.

## What changed

- PowerShell cd hook now runs an explicit initial sync on session start, matching bash/zsh/fish behaviour.
- Hook also clears any inherited `_AM_ALIASES` / `_AM_PROJECT_PATH` before that initial sync, so a stale value from a parent process can't make `am sync` think nothing's missing.
- Precedence diff now unsets `_AM_ALIASES` / `_AM_SUBCOMMANDS` when a change empties them, instead of leaving the old names tracked. Same trap could have bitten any shell on an inherited session.
- Closes #144.