### PR TITLE
fix: avoid shadowing PowerShell $args in dispatch trigger

### DIFF
--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -50,6 +50,6 @@ jobs:
       - name: Pack and push
         shell: pwsh
         run: |
-          $args = @('-Tag', '${{ steps.tag.outputs.value }}')
-          if ('${{ inputs.dry_run }}' -eq 'true') { $args += '-DryRun' }
-          ./packaging/choco/scripts/pack-and-push.ps1 @args
+          $scriptArgs = @('-Tag', '${{ steps.tag.outputs.value }}')
+          if ('${{ inputs.dry_run }}' -eq 'true') { $scriptArgs += '-DryRun' }
+          ./packaging/choco/scripts/pack-and-push.ps1 @scriptArgs


### PR DESCRIPTION
## Why

Manual `publish-chocolatey.yml` dispatch on main failed with `Tag '-Tag' does not match ^v<major>.<minor>.<patch>[-...]`. The workflow's `run:` block assigned to `$args`, which is a PowerShell automatic variable — same footgun caught in Task 9 of the original design where `Invoke-Git`'s parameter was renamed `$Args` → `$GitArgs`. Splatting a shadowed `$args` array through `@args` mis-binds parameters.

## Fix

Rename to `$scriptArgs`. One-line change per side of the assignment + splat.

## Test plan

- [ ] Re-dispatch `publish-chocolatey.yml` against `v0.10.0` with `dry_run=true` after merge — must reach `choco pack` step (fetch succeeds for x64, ARM64 stubbed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chocolatey package publishing reliability by ensuring release and dry-run options are passed correctly during publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->