### PR TITLE
fix: splat script args as hashtable, not array

### DIFF
--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -50,6 +50,8 @@ jobs:
       - name: Pack and push
         shell: pwsh
         run: |
-          $scriptArgs = @('-Tag', '${{ steps.tag.outputs.value }}')
-          if ('${{ inputs.dry_run }}' -eq 'true') { $scriptArgs += '-DryRun' }
+          # Hashtable splat — PowerShell array splat is positional-only, so
+          # @('-Tag', 'v0.10.0') would bind the string '-Tag' as the value of $Tag.
+          $scriptArgs = @{ Tag = '${{ steps.tag.outputs.value }}' }
+          if ('${{ inputs.dry_run }}' -eq 'true') { $scriptArgs.DryRun = $true }
           ./packaging/choco/scripts/pack-and-push.ps1 @scriptArgs


### PR DESCRIPTION
## Why

Follow-up to #160. Manual dispatch of `publish-chocolatey.yml` still failed with `Tag '-Tag' does not match ^v<major>.<minor>.<patch>[-...]` after the `$args` → `$scriptArgs` rename. Root cause: PowerShell array splatting is positional-only, so `@('-Tag', 'v0.10.0')` binds the string `-Tag` as the value of `$Tag`. Reproduced locally with a two-line pwsh test.

## Fix

Splat a hashtable instead — `@{ Tag = 'v0.10.0'; DryRun = $true }` — which uses named-parameter binding.

## Test plan

- [ ] Re-dispatch `publish-chocolatey.yml` against `v0.10.0` with `dry_run=true` after merge — must reach `choco pack`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chocolatey package publishing to apply release tags correctly.
  * Fixed dry-run handling in the publishing workflow to prevent unintended package publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->