### PR TITLE
fix: unbreak aarch64-pc-windows-msvc release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v7
         with:
@@ -117,6 +117,10 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+      # ring 0.17 forces `clang` (not `clang-cl`) for aarch64-pc-windows-msvc;
+      # switch cargo-xwin to the clang backend so /imsvc include paths are formatted
+      # in a form clang understands. Harmless for other targets.
+      XWIN_CROSS_COMPILER: clang
     steps:
       - name: enable windows longpaths
         run: |

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.31.0"
+cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app


### PR DESCRIPTION
## Why

The v0.10.3 release run failed on the `aarch64-pc-windows-msvc` matrix leg — `ring 0.17` refused to compile under `cargo-xwin`'s default `clang-cl` backend, so no Windows-on-ARM artifact ships until this is unstuck.

## What changed

- Set `XWIN_CROSS_COMPILER=clang` on the build-local-artifacts job. `ring`'s build script hard-codes plain `clang` for aarch64, and clang can't parse the `/imsvc <path>` include-flag pairs cargo-xwin emits for its default `clang-cl` backend. The `clang` backend formats them in a form plain clang understands.
- Bump `cargo-dist` to `0.32.0` (routine hygiene alongside a CI-touching change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release tooling to version 0.32.0.
  * Improved Windows artifact builds, including better compiler selection for supported targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->