### PR TITLE
fix: disable blake3 NEON on aarch64-pc-windows-msvc

### DIFF
--- a/crates/am/Cargo.toml
+++ b/crates/am/Cargo.toml
@@ -32,6 +32,12 @@ tempfile = { workspace = true }
 terminal_size = "0.4"
 unicode-width = "0.2"
 
+# blake3's NEON C path won't build under cargo-xwin's clang backend — the
+# msvc-sysroot exposes ARM64 NEON intrinsics as no-op macros that break
+# __builtin_shufflevector. Fall back to the portable path on this target only.
+[target.'cfg(all(target_arch = "aarch64", target_os = "windows"))'.dependencies]
+blake3 = { version = "1", features = ["no_neon"] }
+
 [features]
 test-util = []
 


### PR DESCRIPTION
## Why

The v0.10.4 release still fails on the `aarch64-pc-windows-msvc` leg. With `XWIN_CROSS_COMPILER=clang` (shipped in #163) the msvc-sysroot exposes ARM64 NEON intrinsics as no-op macros — e.g. `#define vreinterpretq_u32_u8(a) (a)` — which makes `blake3_neon.c`'s call to `__builtin_shufflevector` reject a scalar where it wants a vector.

## What changed

- Enable `blake3`'s `no_neon` feature via a target-scoped dependency for `cfg(all(target_arch = "aarch64", target_os = "windows"))`. Every other target keeps the SIMD path — blake3 is only used for trust-content hashing, so the perf cost on this one target is negligible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and stability for users running the application on ARM64-based Windows devices.
  * Resolved a platform-specific issue that could prevent successful builds or operation in this environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->