### PR TITLE
chore: rename deploy-website workflow to publish-website

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [main]
     paths:
-      - 'website/**'
-      - 'community/**'
+      - "website/**"
+      - "community/**"
   workflow_dispatch:
   workflow_call:
 
@@ -13,7 +13,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: deploy-website
+  group: publish-website
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,10 +401,10 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-  deploy-website:
+  publish-website:
     needs:
       - announce
     if: ${{ needs.announce.result == 'success' }}
-    uses: ./.github/workflows/deploy-website.yml
+    uses: ./.github/workflows/publish-website.yml
     permissions:
       contents: write


### PR DESCRIPTION
## Why

The workflow doesn't deploy anything — it publishes the built VitePress site to GitHub Pages. Naming it `publish-website` lines it up with the other `publish-*` workflows (chocolatey, crates) and stops the mental hop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Updated the release automation to publish the website through the standardized publishing workflow.
  * Improved deployment concurrency handling to prevent overlapping website publishing runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->