### PR TITLE
fix: decode choco sidecar body as string, not bytes

### DIFF
--- a/packaging/choco/scripts/pack-and-push.lib.ps1
+++ b/packaging/choco/scripts/pack-and-push.lib.ps1
@@ -63,6 +63,10 @@ function Get-ReleaseNotesFromTag {
 function Get-Sha256FromUrl {
     [CmdletBinding()]
     param([Parameter(Mandatory)][string]$Url)
-    $resp = Invoke-WebRequest -Uri $Url -UseBasicParsing
-    return ConvertFrom-Sha256Sidecar -Content $resp.Content
+    # GitHub serves release sidecars as application/octet-stream, which makes
+    # Invoke-WebRequest return $resp.Content as byte[] under PowerShell 7 —
+    # that breaks the [string] param on ConvertFrom-Sha256Sidecar.
+    # Invoke-RestMethod decodes the body to string for us.
+    $body = Invoke-RestMethod -Uri $Url
+    return ConvertFrom-Sha256Sidecar -Content $body
 }


### PR DESCRIPTION
## Why

Every real-tag Chocolatey publish since v0.10.0 has failed on the same line — `Cannot convert value to type System.String` when reading the `.sha256` sidecar. GitHub serves those sidecars as `application/octet-stream`, and PowerShell 7's `Invoke-WebRequest` hands back `$resp.Content` as `byte[]` for non-text bodies, which the `[string]$Content` param on `ConvertFrom-Sha256Sidecar` refuses.

The dry-run path never noticed because its `catch` swallowed the type error and substituted a stub hash, so tests kept passing.

## What changed

- Swap `Invoke-WebRequest` for `Invoke-RestMethod` in `Get-Sha256FromUrl` — it decodes the body to string regardless of content-type. Verified locally against the live v0.10.5 sidecar URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SHA256 checksum retrieval during package installation and publishing.
  * Resolved compatibility issues affecting checksum parsing in PowerShell 7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->